### PR TITLE
issue/3236 Add full es6 class support to backbone

### DIFF
--- a/libraries/backbone.es6.js
+++ b/libraries/backbone.es6.js
@@ -5,7 +5,7 @@
  * Added ES6-style constructor and static property inheritance rather than just
  * copying the enumerable static properties each time.
  */
- define('backbone.es6', [
+define('backbone.es6', [
   'underscore',
   'backbone',
   'backbone.controller'

--- a/libraries/backbone.es6.js
+++ b/libraries/backbone.es6.js
@@ -1,22 +1,39 @@
 /**
- * 2020-03-19 https://github.com/adaptlearning/adapt_framework/issues/2697
- * Added ES6-style constructor and static property inheritance rather than just 
+ * 2021-09-07
+ * https://github.com/adaptlearning/adapt_framework/issues/2697
+ * https://github.com/adaptlearning/adapt_framework/issues/3236
+ * Added ES6-style constructor and static property inheritance rather than just
  * copying the enumerable static properties each time.
  */
-define('backbone.es6', [
+ define('backbone.es6', [
   'underscore',
   'backbone',
   'backbone.controller'
 ], function(_, Backbone) {
 
-  var classes = [ 
-    Backbone.View, 
-    Backbone.Model, 
-    Backbone.Collection, 
-    Backbone.Router, 
-    Backbone.History, 
-    Backbone.Controller 
+  var hasNativeClassSupport = true;
+  try {
+    eval('class A {}');
+  } catch(err) {
+    hasNativeClassSupport = false;
+  }
+
+  var classes = [
+    Backbone.View,
+    Backbone.Model,
+    Backbone.Collection,
+    Backbone.Router,
+    Backbone.History,
+    Backbone.Controller
   ];
+
+  if (hasNativeClassSupport) {
+    // Transform Backbone classes into ES6 Classes
+    ['View', 'Model', 'Collection', 'Router', 'History', 'Controller'].forEach(function(name) {
+      Backbone['_' + name]= Backbone[name];
+      Backbone[name] = eval('class ' + name + ' extends Backbone["_'+name+'"] { }; ' + name + ';');
+    });
+  }
 
   // Helper function to correctly set up the prototype chain for subclasses.
   // Similar to `goog.inherits`, but uses a hash of prototype properties and
@@ -28,10 +45,18 @@ define('backbone.es6', [
     // The constructor function for the new subclass is either defined by you
     // (the "constructor" property in your `extend` definition), or defaulted
     // by us to simply call the parent constructor.
-    if (protoProps && _.has(protoProps, 'constructor')) {
-      child = protoProps.constructor;
+    if (hasNativeClassSupport) {
+      if (protoProps && _.has(protoProps, 'constructor')) {
+        child = eval('class e extends protoProps.constructor { }; e;');
+      } else {
+        child = eval('class e extends parent { }; e;');
+      }
     } else {
-      child = function(){ return parent.apply(this, arguments); };
+      if (protoProps && _.has(protoProps, 'constructor')) {
+        child = protoProps.constructor;
+      } else {
+        child = function(){ return parent.apply(this, arguments); };
+      }
     }
 
     // Create static property inheritance chain
@@ -40,9 +65,15 @@ define('backbone.es6', [
     // Add new static properties values to the constructor function, if supplied.
     _.extend(child, staticProps);
 
-    // Set the prototype chain to inherit from `parent`, without calling
-    // `parent`'s constructor function and add the prototype properties.
-    child.prototype = _.create(parent.prototype, protoProps);
+    // Set the prototype  inheritance chain
+    // Add new prototype properties to class prototype
+    if (!hasNativeClassSupport) {
+      child.prototype = _.create(parent.prototype, protoProps);
+    } else {
+      child.prototype = {};
+      Object.setPrototypeOf(child.prototype, parent.prototype);
+      _.extend(child.prototype, protoProps);
+    }
     child.prototype.constructor = child;
 
     // Set a convenience property in case the parent's prototype is needed
@@ -55,5 +86,31 @@ define('backbone.es6', [
   classes.forEach(function(Class) {
     Class.extend = extend;
   });
+
+  // Fixes for Backbone.Collection in ES6 class environment
+  Backbone.Collection.prototype.model = Backbone.Model;
+  Backbone.Collection.prototype.modelId = function(t) {
+    return t[(this.model.prototype && this.model.prototype.idAttribute) || "id"];
+  };
+  Backbone.Collection.prototype._prepareModel = function(t, e) {
+    if (this._isModel(t)) {
+        if (!t.collection)
+            t.collection = this;
+        return t
+    }
+    e = e ? _.clone(e) : {};
+    e.collection = this;
+    var n;
+    if (this.model === Backbone.Model || this.model.prototype instanceof Backbone.Model) {
+      var Class = this.model;
+      n = new Class(t,e);
+    } else {
+      n = this.model(t,e);
+    }
+    if (!n.validationError)
+        return n;
+    this.trigger("invalid", this, n.validationError, e);
+    return false
+  };
 
 });


### PR DESCRIPTION
part fix for https://github.com/adaptlearning/adapt_framework/issues/3236

### Fixed
* Allow backbone classes to be used in a native ES6 environment

### Testing
* Use adapt_framework branch [issue/3236](https://github.com/adaptlearning/adapt_framework/tree/issue/3236) [pr#3237](https://github.com/adaptlearning/adapt_framework/pull/3237) remove `ie11` line from [.browserslistrc](https://github.com/adaptlearning/adapt_framework/blob/f46f558ce3b4d03f54751ee0d115947725047e83/.browserslistrc#L9) and `grunt dev`