### PR TITLE
issue/11 Cleared up reset and isResetOnRevisit code

### DIFF
--- a/js/models/adaptModel.js
+++ b/js/models/adaptModel.js
@@ -28,7 +28,7 @@ export default class AdaptModel extends LockingModel {
     return {
       _canShowFeedback: true,
       _classes: '',
-      _canReset: false,
+      _canReset: true,
       _canRequestChild: false,
       _isComplete: false,
       _isInteractionComplete: false,
@@ -220,26 +220,30 @@ export default class AdaptModel extends LockingModel {
 
   }
 
-  reset(type, force) {
-    if (!this.get('_canReset') && !force) return;
-
-    type = type || true;
-
+  /**
+   * @param {string} [type] 'hard' resets _isComplete and _isInteractionComplete, 'soft' resets _isInteractionComplete only.
+   * @param {boolean} [canReset] Defaults to this.get('_canReset')
+   * @returns {boolean}
+   */
+  reset(type = 'hard', canReset = this.get('_canReset')) {
+    if (!canReset) return false;
     switch (type) {
-      case 'hard': case true:
+      case 'hard':
+      case true:
         this.set({
           _isEnabled: true,
           _isComplete: false,
           _isInteractionComplete: false
         });
-        break;
+        return true;
       case 'soft':
         this.set({
           _isEnabled: true,
           _isInteractionComplete: false
         });
-        break;
+        return true;
     }
+    return false;
   }
 
   /**
@@ -756,7 +760,7 @@ export default class AdaptModel extends LockingModel {
     return lockedBy.some(id => {
       try {
         const anotherModel = Adapt.findById(id);
-        return anotherModel.get('_isAvailable') && 
+        return anotherModel.get('_isAvailable') &&
           (
             anotherModel.get('_isLocked') ||
             (
@@ -783,10 +787,6 @@ export default class AdaptModel extends LockingModel {
    */
   checkIfResetOnRevisit() {
     const isResetOnRevisit = this.get('_isResetOnRevisit');
-    if (!isResetOnRevisit) {
-      return;
-    }
-    // If reset is enabled set defaults
     this.reset(isResetOnRevisit);
   }
 

--- a/js/models/componentModel.js
+++ b/js/models/componentModel.js
@@ -77,10 +77,16 @@ class ComponentModel extends AdaptModel {
     this.set('_userAnswer', null);
   }
 
-  reset(type, force) {
-    if (!this.get('_canReset') && !force) return;
+  /**
+   * @param {string} [type] 'hard' resets _isComplete and _isInteractionComplete, 'soft' resets _isInteractionComplete only.
+   * @param {boolean} [canReset] Defaults to this.get('_canReset')
+   * @returns {boolean}
+   */
+  reset(type = 'hard', canReset = this.get('_canReset')) {
+    const wasReset = super.reset(type, canReset);
+    if (!wasReset) return false;
     this.resetUserAnswer();
-    super.reset(type, force);
+    return true;
   }
 
   /**

--- a/js/models/itemsComponentModel.js
+++ b/js/models/itemsComponentModel.js
@@ -13,7 +13,7 @@ export default class ItemsComponentModel extends ComponentModel {
   init() {
     this.setUpItems();
     this.listenTo(this.getChildren(), {
-      'all': this.onAll,
+      all: this.onAll,
       'change:_isVisited': this.checkCompletionStatus
     });
     super.init();
@@ -63,9 +63,16 @@ export default class ItemsComponentModel extends ComponentModel {
     this.setCompletionStatus();
   }
 
-  reset(type, force) {
+  /**
+   * @param {string} [type] 'hard' resets _isComplete and _isInteractionComplete, 'soft' resets _isInteractionComplete only.
+   * @param {boolean} [canReset] Defaults to this.get('_canReset')
+   * @returns {boolean}
+   */
+  reset(type = 'hard', canReset = this.get('_canReset')) {
+    const wasReset = super.reset(type, canReset);
+    if (!wasReset) return false;
     this.getChildren().each(item => item.reset());
-    super.reset(type, force);
+    return true;
   }
 
   resetActiveItems() {

--- a/js/models/itemsQuestionModel.js
+++ b/js/models/itemsQuestionModel.js
@@ -9,9 +9,14 @@ class BlendedItemsComponentQuestionModel extends QuestionModel {
     super.init();
   }
 
-  reset(type, force) {
-    ItemsComponentModel.prototype.reset.call(this, type, force);
-    super.reset(type, force);
+  /**
+   * @param {string} [type] 'hard' resets _isComplete and _isInteractionComplete, 'soft' resets _isInteractionComplete only.
+   * @param {boolean} [canReset] Defaults to this.get('_canReset')
+   * @returns {boolean}
+   */
+  reset(type = 'hard', canReset = this.get('_canReset')) {
+    ItemsComponentModel.prototype.reset.call(this, type, canReset);
+    return super.reset(type, canReset);
   }
 
 }
@@ -27,7 +32,10 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
 
   init() {
     super.init();
-    this.set('_isRadio', this.isSingleSelect());
+    this.set({
+      _isCorrectAnswerShown: false,
+      _isRadio: this.isSingleSelect()
+    });
     this.listenTo(this.getChildren(), 'change:_isActive', this.checkCanSubmit);
     this.checkCanSubmit();
   }

--- a/js/models/questionModel.js
+++ b/js/models/questionModel.js
@@ -283,14 +283,24 @@ class QuestionModel extends ComponentModel {
     return !this.get('_isComplete') || (this.get('_isEnabled') && !this.get('_isSubmitted'));
   }
 
-  // Reset the model to let the user have another go (not the same as attempts)
-  reset(type, force) {
-    if (!this.get('_canReset') && !force) return;
+  checkIfResetOnRevisit() {
+    super.checkIfResetOnRevisit();
+    // Setup button view state
+    this.set('_buttonState', this.get('_isInteractionComplete')
+      ? BUTTON_STATE.HIDE_CORRECT_ANSWER
+      : BUTTON_STATE.SUBMIT
+    );
+  }
 
-    type = type || true; // hard reset by default, can be "soft", "hard"/true
-
-    super.reset(type, force);
-
+  /**
+   * Reset the model to let the user have another go (not the same as attempts)
+   * @param {string} [type] 'hard' resets _isComplete and _isInteractionComplete, 'soft' resets _isInteractionComplete only.
+   * @param {boolean} [canReset] Defaults to this.get('_canReset')
+   * @returns {boolean}
+   */
+  reset(type = 'hard', canReset = this.get('_canReset')) {
+    const wasReset = super.reset(type, canReset);
+    if (!wasReset) return false;
     const attempts = this.get('_attempts');
     this.set({
       _attemptsLeft: attempts,
@@ -298,6 +308,7 @@ class QuestionModel extends ComponentModel {
       _isSubmitted: false,
       _buttonState: BUTTON_STATE.SUBMIT
     });
+    return true;
   }
 
   // Reset question for subsequent attempts


### PR DESCRIPTION
part of #11 

### Changed
* `_canReset` defaults to `true` instead of `false` such that it becomes a blocker for `reset`, as it should be
* All `reset` functions have comment, defined defaults and return `true` or `false` for 'was reset'
* Linting corrections
* Moved more of the `_isCorrectAnswerShown` behaviour back from the `McqModel` into the `ItemsQuestionModel`

### Deprecated
* `QuestionView.prototype.checkIfResetOnRevisit` and `QuestionView.prototype.resetQuestionOnRevisit` such that reset on revisit must be performed in the model
* Moved some essential `QuestionView.prototype.checkIfResetOnRevisit` behaviour into a new private function called `QuestionView.prototype.ensureLegacyLifeCycleState`, which allows older components to configure their view state as with complete or incomplete