### PR TITLE
issue/2967 Reworked scrollingContainer

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -69,7 +69,7 @@ class Router extends Backbone.Router {
       this.navigate('#/' + args.join('/'), options);
       return;
     }
-    Adapt.log.deprecated(`Use Backbone.history.navigate or window.location.href instead of Adapt.trigger('router:navigateTo')`);
+    Adapt.log.deprecated('Use Backbone.history.navigate or window.location.href instead of Adapt.trigger(\'router:navigateTo\')');
     this.handleRoute(...args);
   }
 
@@ -368,8 +368,9 @@ class Router extends Backbone.Router {
     }
 
     // Get the current location - this is set in the router
-    const location = (Adapt.location._contentType) ?
-      Adapt.location._contentType : Adapt.location._currentLocation;
+    const location = (Adapt.location._contentType)
+      ? Adapt.location._contentType
+      : Adapt.location._currentLocation;
     // Trigger initial scrollTo event
     Adapt.trigger(`${location}:scrollTo`, selector);
     // Setup duration variable
@@ -380,13 +381,10 @@ class Router extends Backbone.Router {
       settings.duration = $.scrollTo.defaults.duration;
     }
 
-    let offsetTop = 0;
-    if (Adapt.scrolling.isLegacyScrolling) {
-      offsetTop = -$('.nav').outerHeight();
-      // prevent scroll issue when component description aria-label coincident with top of component
-      if ($(selector).hasClass('component')) {
-        offsetTop -= $(selector).find('.aria-label').height() || 0;
-      }
+    let offsetTop = -$('.nav').outerHeight();
+    // prevent scroll issue when component description aria-label coincident with top of component
+    if ($(selector).hasClass('component')) {
+      offsetTop -= $(selector).find('.aria-label').height() || 0;
     }
 
     if (!settings.offset) settings.offset = { top: offsetTop, left: 0 };

--- a/js/scrolling.js
+++ b/js/scrolling.js
@@ -55,15 +55,17 @@ class Scrolling extends Backbone.Controller {
       get: () => app.scrollWidth,
       set: value => (app.scrollWidth = value)
     };
-    // Fix window.scrollY, window.scrollX, window.pageYOffsert and window.pageXOffset
+    // Fix window.scrollY, window.scrollX, window.pageYOffset and window.pageXOffset
     Object.defineProperties(window, {
       scrollY,
       scrollX,
+      // Note: jQuery uses pageYOffset and pageXOffset instead of scrollY and scrollX
       pageYOffset: scrollY,
       pageXOffset: scrollX
     });
     // Fix html.scrollHeight and html.scrollWidth
     Object.defineProperties(html, {
+      // Note: jQuery animate as used in scrollTo library, uses scrollHeight to determine animation maxiumum
       scrollHeight,
       scrollWidth
     });
@@ -82,6 +84,7 @@ class Scrolling extends Backbone.Controller {
         get: function() { return this.clientX + scrollX.get(); }
       },
       pageY: {
+        // Note: MediaElementJS uses event.pageY to work out the mouse position for the volume controls
         get: function() { return this.clientY + scrollY.get(); }
       }
     });

--- a/less/core/scrolling.less
+++ b/less/core/scrolling.less
@@ -5,6 +5,8 @@
 
 html.adapt-scrolling {
   .restrain-height;
+  // Allow overflow scroll top for refresh on android
+  overflow-y: auto;
 
   body, #app {
     .restrain-height;


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/2967

### Fixed
* Replaced jquery based fix with browser based fix to enhance the embeddedness of the solution
  * Replaced `window.scrollY`, `window.scrollX`, `window.pageYOffset`, `window.pageXOffset`, `html.scrollHeight`, `html.scrollWidth` and `window.scrollTo` so that they have impact on the `#app` container and use its values rather than those from the `html` tag
* Added `MouseEvent` fix to ensure `event.pageX` and `event.pageY` are relative to the scroll of the `#app` container rather than the `html` tag
  * Replaced `MouseEvent.prototype.pageX` and `MouseEvent.prototype.pageY` so that they take the approprate values from the `#app` container scroll position rather than the `html` tag scroll position

### Changed
* Linting issues

### Testing
1. Clone the framework and set core to the correct branch:
```sh
git clone https://github.com/adaptlearning/adapt_framework 2967
cd 2967
npm install && adapt devinstall
cd src/core
git checkout issue/2967
cd ../../
```

2. Enable the scrolling container by changing `src/course/config.json` `_scrollingContainer._isEnabled` to `true`.
3. Add volume controls to the media component by adding to `src/course/en/components.json` component `c-40`, `"_showVolumeControl": true,`

3. Build the project:
```sh
grunt dev
```