### PR TITLE
issue/2967-b Scrolling container rewrite

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -381,8 +381,10 @@ class Router extends Backbone.Router {
       settings.duration = $.scrollTo.defaults.duration;
     }
 
-    let offsetTop = -$('.nav').outerHeight();
-    // prevent scroll issue when component description aria-label coincident with top of component
+    const $wrapper = $('#wrapper');
+    // Work out offset from the top of the wrapper rather than the height of the navigation bar
+    let offsetTop = -parseInt($wrapper.css('padding-top'));
+    // Prevent scroll issue when component description aria-label coincident with top of component
     if ($(selector).hasClass('component')) {
       offsetTop -= $(selector).find('.aria-label').height() || 0;
     }

--- a/js/router.js
+++ b/js/router.js
@@ -69,7 +69,7 @@ class Router extends Backbone.Router {
       this.navigate('#/' + args.join('/'), options);
       return;
     }
-    Adapt.log.deprecated(`Use Backbone.history.navigate or window.location.href instead of Adapt.trigger('router:navigateTo')`);
+    Adapt.log.deprecated('Use Backbone.history.navigate or window.location.href instead of Adapt.trigger(\'router:navigateTo\')');
     this.handleRoute(...args);
   }
 
@@ -368,8 +368,9 @@ class Router extends Backbone.Router {
     }
 
     // Get the current location - this is set in the router
-    const location = (Adapt.location._contentType) ?
-      Adapt.location._contentType : Adapt.location._currentLocation;
+    const location = (Adapt.location._contentType)
+      ? Adapt.location._contentType
+      : Adapt.location._currentLocation;
     // Trigger initial scrollTo event
     Adapt.trigger(`${location}:scrollTo`, selector);
     // Setup duration variable
@@ -380,13 +381,10 @@ class Router extends Backbone.Router {
       settings.duration = $.scrollTo.defaults.duration;
     }
 
-    let offsetTop = 0;
-    if (Adapt.scrolling.isLegacyScrolling) {
-      offsetTop = -$('.nav').outerHeight();
-      // prevent scroll issue when component description aria-label coincident with top of component
-      if ($(selector).hasClass('component')) {
-        offsetTop -= $(selector).find('.aria-label').height() || 0;
-      }
+    let offsetTop = -$('.nav').outerHeight();
+    // prevent scroll issue when component description aria-label coincident with top of component
+    if ($(selector).hasClass('component')) {
+      offsetTop -= $(selector).find('.aria-label').height() || 0;
     }
 
     if (!settings.offset) settings.offset = { top: offsetTop, left: 0 };

--- a/js/scrolling.js
+++ b/js/scrolling.js
@@ -15,20 +15,8 @@ class Scrolling extends Backbone.Controller {
 
   initialize() {
     this.$html = null;
-    this.$app = null;
     this.isLegacyScrolling = true;
-    this._checkApp();
     Adapt.once('configModel:dataLoaded', this._loadConfig.bind(this));
-  }
-
-  _checkApp() {
-    this.$html = $('html');
-    this.$app = $('#app');
-    if (this.$app.length) return;
-    this.$app = $('<div id="app">');
-    $('body').append(this.$app);
-    this.$app.append($('#wrapper'));
-    Adapt.log.warn('UPDATE - Your html file needs to have #app adding. See https://github.com/adaptlearning/adapt_framework/issues/2168');
   }
 
   _loadConfig() {
@@ -72,23 +60,23 @@ class Scrolling extends Backbone.Controller {
    */
   _windowScrollFix() {
     /** @type {HTMLDivElement} */
-    const app = document.body;
+    const body = document.body;
     const html = Adapt.scrolling.$html[0];
     const scrollY = {
-      get: () => app.scrollTop,
-      set: value => (app.scrollTop = value)
+      get: () => body.scrollTop,
+      set: value => (body.scrollTop = value)
     };
     const scrollX = {
-      get: () => app.scrollLeft,
-      set: value => (app.scrollLeft = value)
+      get: () => body.scrollLeft,
+      set: value => (body.scrollLeft = value)
     };
     const scrollHeight = {
-      get: () => app.scrollHeight,
-      set: value => (app.scrollHeight = value)
+      get: () => body.scrollHeight,
+      set: value => (body.scrollHeight = value)
     };
     const scrollWidth = {
-      get: () => app.scrollWidth,
-      set: value => (app.scrollWidth = value)
+      get: () => body.scrollWidth,
+      set: value => (body.scrollWidth = value)
     };
     // Fix window.scrollY, window.scrollX, window.pageYOffset and window.pageXOffset
     Object.defineProperties(window, {
@@ -109,8 +97,8 @@ class Scrolling extends Backbone.Controller {
       const isObject = (args.length === 1 && typeof args[0] === 'object' && args[0] !== null);
       const left = (isObject ? args[0].left : args[0]) ?? null;
       const top = (isObject ? args[0].top : args[1]) ?? null;
-      left !== null && (app.scrollLeft = left);
-      top !== null && (app.scrollTop = top);
+      left !== null && (body.scrollLeft = left);
+      top !== null && (body.scrollTop = top);
     };
     // Fix MouseEvent.prototype.pageX and MouseEvent.prototype.pageY
     const MouseEvent = window.MouseEvent;

--- a/js/scrolling.js
+++ b/js/scrolling.js
@@ -14,7 +14,7 @@ import Adapt from 'core/js/adapt';
 class Scrolling extends Backbone.Controller {
 
   initialize() {
-    this.$html = null;
+    this.$html = $('html');
     this.isLegacyScrolling = true;
     Adapt.once('configModel:dataLoaded', this._loadConfig.bind(this));
   }

--- a/js/scrolling.js
+++ b/js/scrolling.js
@@ -55,15 +55,17 @@ class Scrolling extends Backbone.Controller {
       get: () => app.scrollWidth,
       set: value => (app.scrollWidth = value)
     };
-    // Fix window.scrollY, window.scrollX, window.pageYOffsert and window.pageXOffset
+    // Fix window.scrollY, window.scrollX, window.pageYOffset and window.pageXOffset
     Object.defineProperties(window, {
       scrollY,
       scrollX,
+      // Note: jQuery uses pageYOffset and pageXOffset instead of scrollY and scrollX
       pageYOffset: scrollY,
       pageXOffset: scrollX
     });
     // Fix html.scrollHeight and html.scrollWidth
     Object.defineProperties(html, {
+      // Note: jQuery animate as used in scrollTo library, uses scrollHeight to determine animation maxiumum
       scrollHeight,
       scrollWidth
     });
@@ -82,6 +84,7 @@ class Scrolling extends Backbone.Controller {
         get: function() { return this.clientX + scrollX.get(); }
       },
       pageY: {
+        // Note: MediaElementJS uses event.pageY to work out the mouse position for the volume controls
         get: function() { return this.clientY + scrollY.get(); }
       }
     });

--- a/less/core/scrolling.less
+++ b/less/core/scrolling.less
@@ -8,22 +8,19 @@ html.adapt-scrolling {
   // Allow overflow scroll top for refresh on android
   overflow-y: auto;
 
-  body, #app {
-    .restrain-height;
-  }
-
+  // Offset the navigation bar width the the body scrollbar
   .nav {
-    position: relative;
+    // IE11 is consistant at 18px
+    width: calc(100% - 18px);
+    // Modern browsers change their scroll bar width on zoom
+    width: calc(100% - var(--adapt-scrollbar-width));
   }
 
-  #app {
+  body {
+    .restrain-height;
     position: relative;
-    height: calc(~'100% - @{navigation-height}');
     overflow-y: scroll;
+    // Allow scrolling of the body in an iframe on ios
     -webkit-overflow-scrolling: touch;
-  }
-
-  #wrapper {
-    padding: 0;
   }
 }

--- a/less/core/scrolling.less
+++ b/less/core/scrolling.less
@@ -1,12 +1,7 @@
-.restrain-height() {
-  height: 100%;
-  overflow: hidden;
-}
-
 html.adapt-scrolling {
-  .restrain-height;
+  height: 100%;
   // Allow overflow scroll top for refresh on android
-  overflow-y: auto;
+  overflow: auto;
 
   // Offset the navigation bar width the the body scrollbar
   .nav {
@@ -17,7 +12,8 @@ html.adapt-scrolling {
   }
 
   body {
-    .restrain-height;
+    height: 100%;
+    overflow: hidden;
     position: relative;
     overflow-y: scroll;
     // Allow scrolling of the body in an iframe on ios

--- a/less/core/scrolling.less
+++ b/less/core/scrolling.less
@@ -5,6 +5,8 @@
 
 html.adapt-scrolling {
   .restrain-height;
+  // Allow overflow scroll top for refresh on android
+  overflow-y: auto;
 
   body, #app {
     .restrain-height;

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -380,7 +380,7 @@
         "_isEnabled": {
           "type": "boolean",
           "title": "Enable fixes",
-          "default": false
+          "default": true
         },
         "_limitToSelector": {
           "type": "string",


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/2967

alternative to https://github.com/adaptlearning/adapt-contrib-core/pull/15

### Differences
* The scrolling container will be enabled by default
* Instead of scrolling using the viewport to scroll, Adapt would use the `body` tag to scroll rather than `#app` tag as before 
* The navigation bar can remain fixed position rather than being relative, as it was with the old implementation
* The content can reach from the top of the screen under the navigation bar, to the bottom screen, rather than from under the navigation bar to the bottom of the screen, which brings the behaviour inline in both modes
* The navigation bar width must be offset for the `body` element's scrollbar, this is as unlike the viewport scrollbar the body scrollbar does not automatically constrain the fixed position navigation bar width by those extra 18px
* The scrollbar width is calculated automatically and is stored in a css variable so that the browser can apply the styling to the navigation bar automatically (IE11 has a fallback style for 18px, which never changes, Safari has floating scrollbars and so is always calculated as 0px)

### Impact
* With both the scrolling container enabled and disabled, Adapt can be styled identically, which it could not be before [see here](https://github.com/adaptlearning/adapt_framework/issues/2710)
* Adapt will work in ios iframes by default
* [This new ios bug](https://github.com/adaptlearning/adapt-contrib-trickle/issues/132) (presenting in trickle) will be fixed, which occurs as there is a 44px zone at the bottom of mobile safari that prevents the trickle button from being clicked ([referenced here](https://www.eventbrite.com/engineering/mobile-safari-why/)) but the click instead activates the bottom browser menu. With the scrolling container enabled, this pr forces the browser navigation bars to be always present

### Fixed
* Replaced jquery based fix with browser based fix to enhance the embeddedness of the solution
  * Replaced `window.scrollY`, `window.scrollX`, `window.pageYOffset`, `window.pageXOffset`, `html.scrollHeight`, `html.scrollWidth` and `window.scrollTo` so that they have impact on the `body` container and use its values rather than those from the `html` tag
* Added `MouseEvent` fix to ensure `event.pageX` and `event.pageY` are relative to the scroll of the `body` container rather than the `html` tag
  * Replaced `MouseEvent.prototype.pageX` and `MouseEvent.prototype.pageY` so that they take the approprate values from the `body` container scroll position rather than the `html` tag scroll position  

### Changed
* Linting issues

### Testing
1. Clone the framework and set core to the correct branch:
```sh
git clone https://github.com/adaptlearning/adapt_framework 2967-b
cd 2967-b
npm install && adapt devinstall
cd src/core
git checkout issue/2967-b
cd ../../
```

2. Enable the scrolling container by changing `src/course/config.json` `_scrollingContainer._isEnabled` to `true`.
3. Add volume controls to the media component by adding to `src/course/en/components.json` component `c-40`, `"_showVolumeControl": true,`

3. Build the project:
```sh
grunt dev
```

### ios iframe test
[iframe.zip](https://github.com/adaptlearning/adapt-contrib-core/files/7252103/iframe.zip)

Place the `iframe.html` file contained in the above zip, alongside `index.html` in the build folder. Open the `iframe.html` on an iphone/ipad.

Or upload to an lms which embeds the course in an iframe
