### PR TITLE
issue/10-2 Removed defer from startController router change

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -181,8 +181,7 @@ class Data extends AdaptCollection {
 
   performStartController() {
     Adapt.startController.loadCourseData();
-    if (!Adapt.startController.isEnabled()) return;
-    const hash = Adapt.startController.getStartHash(false);
+    const hash = Adapt.startController.isEnabled() ? Adapt.startController.getStartHash(false) : '#/';
     Adapt.router.navigate(hash, { trigger: true, replace: true });
   }
 

--- a/js/data.js
+++ b/js/data.js
@@ -20,8 +20,8 @@ class Data extends AdaptCollection {
   initialize() {
     super.initialize();
     this.on({
-      'add': this.onAdded,
-      'remove': this.onRemoved
+      add: this.onAdded,
+      remove: this.onRemoved
     });
   }
 
@@ -136,7 +136,7 @@ class Data extends AdaptCollection {
     // Add course model first to allow other model/views to utilize its settings
     const course = allModelData.find(modelData => modelData._type === 'course');
     if (!course) {
-      throw new Error(`Expected a model data with "_type": "course", none found.`);
+      throw new Error('Expected a model data with "_type": "course", none found.');
     }
     Adapt.trigger('courseModel:dataLoading');
     Adapt.course = this.push(course);
@@ -168,11 +168,7 @@ class Data extends AdaptCollection {
   async triggerDataReady(newLanguage) {
     if (newLanguage) {
       Adapt.trigger('app:languageChanged', newLanguage);
-      _.defer(() => {
-        Adapt.startController.loadCourseData();
-        const hash = Adapt.startController.isEnabled() ? Adapt.startController.getStartHash(false) : '#/';
-        Adapt.router.navigate(hash, { trigger: true, replace: true });
-      });
+      this.performStartController();
     }
     Adapt.log.debug('Firing app:dataReady');
     try {
@@ -181,6 +177,13 @@ class Data extends AdaptCollection {
       Adapt.log.error('Error during app:dataReady trigger', e);
     }
     await Adapt.wait.queue();
+  }
+
+  performStartController() {
+    Adapt.startController.loadCourseData();
+    if (!Adapt.startController.isEnabled()) return;
+    const hash = Adapt.startController.getStartHash(false);
+    Adapt.router.navigate(hash, { trigger: true, replace: true });
   }
 
   triggerInit() {


### PR DESCRIPTION
fixes #10 

### Fixed
* Double `routeId` call by removing defer

### Changed
* Moved startcontroller behaviour into a separate function to make it clearer
* Linting issues

### Notes
The double call seems to be happening because of [this defer](https://github.com/adaptlearning/adapt-contrib-core/blob/dc9e3c22acd67120d0cb7f7fd844e6df03a16f2e/js/data.js#L171) (which was inherited from [this ancient commit](https://github.com/adaptlearning/adapt-contrib-core/commit/50990850e561f12042446bcc5a4cec7deda3ec85#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aR56) through [here](https://github.com/adaptlearning/adapt-contrib-core/commit/36317b1c9626cd88e6a9dae12fc28694b480f5e6)) and the gap between [`_canNavigate: false`](https://github.com/adaptlearning/adapt-contrib-core/blob/dc9e3c22acd67120d0cb7f7fd844e6df03a16f2e/js/router.js#L94) and waiting for the content object to be ready at [`_canNavigate: true`](https://github.com/adaptlearning/adapt-contrib-core/blob/master/js/router.js#L189).

Effectively, it seems that because of the defer, it tries to route to `#/` or the start controller hash, almost immediately after the data is loaded and halfway through the content object readiness. I don't see any need for that defer now. If it's removed we can switch the router to the default hash before it has been through the first routing cycle. That means that the `_canNavigate` + `back` issue disappears.