### PR TITLE
issue/62 Removed page:scrollTo from notifyPopupView removal

### DIFF
--- a/js/views/notifyPopupView.js
+++ b/js/views/notifyPopupView.js
@@ -36,7 +36,7 @@ export default class NotifyPopupView extends Backbone.View {
 
   setupEventListeners() {
     this.listenTo(Adapt, {
-      'remove page:scrollTo': this.closeNotify,
+      remove: this.closeNotify,
       'notify:resize': this.resetNotifySize,
       'notify:cancel': this.cancelNotify,
       'notify:close': this.closeNotify,


### PR DESCRIPTION
fixes #62 

### Removed
* Unusual event listener cause erroneous remove on notify