### PR TITLE
issue/3091 Added longDescriptionId, classes and id to image.jsx

### DIFF
--- a/templates/image.jsx
+++ b/templates/image.jsx
@@ -23,10 +23,14 @@ export default function Image(props) {
   if (!hasSource) return null;
   const attributionClassNamePrefixes = (props.attributionClassNamePrefixes || props.classNamePrefixes);
   return (
-    <div className={classes([
-      prefixClasses(props.classNamePrefixes, ['__image-container']),
-      props.attribution && 'has-attribution'
-    ])}>
+    <div
+      id={props.id}
+      className={classes([
+        prefixClasses(props.classNamePrefixes, ['__image-container']),
+        props.classes,
+        props.attribution && 'has-attribution'
+      ])}
+    >
 
       <img
         className={prefixClasses(props.classNamePrefixes, ['__image'])}
@@ -34,6 +38,7 @@ export default function Image(props) {
         aria-label={Adapt.a11y.normalize(props.alt)}
         aria-hidden={!props.alt}
         loading='eager'
+        aria-describedby={props.longdescription ? props.longDescriptionId : undefined}
       />
 
       {props.attribution &&


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/3091
fixes https://github.com/adaptlearning/adapt-contrib-graphic/issues/82

### Added
* property `longDescriptionId` for specifiying a container id for the image long description
* property `classes` to allow adding classes to the container
* property `id` to allow giving the container an id