### PR TITLE
issue/1448 Do not report failure if able to retry

### DIFF
--- a/js/tracking.js
+++ b/js/tracking.js
@@ -70,6 +70,11 @@ class Tracking extends Backbone.Controller {
     if (completionData.status === COMPLETION_STATE.INCOMPLETE) {
       return;
     }
+    
+    const canRetry = (completionData.assessment?.canRetry === true);
+    if (completionData.status === COMPLETION_STATE.FAILED && canRetry) {
+      return;
+    }
 
     Adapt.trigger('tracking:complete', completionData);
     Adapt.log.debug('tracking:complete', completionData);


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/1448

### Fixed
* Only report `_onAssessmentFailed` status when no more attempts are possible



Requires https://github.com/adaptlearning/adapt-contrib-assessment/pull/154