### PR TITLE
issue/92 Check for readable content in [role=heading]

### DIFF
--- a/js/a11y.js
+++ b/js/a11y.js
@@ -379,8 +379,11 @@ class A11y extends Backbone.Controller {
 
     // check that the component is natively tabbable or
     // will be knowingly read by a screen reader
-    const hasNativeFocusOrIsScreenReadable = $element.is(config._options._focusableElements) ||
-      $element.is(config._options._readableElements);
+    const hasReadableContent = (!/^\s*$/.test($element.text()) ||
+      !/^\s*$/.test($element.attr('aria-label') ?? '') ||
+      !/^\s*$/.test($element.attr('aria-labelledby') ?? ''));
+    const hasNativeFocusOrIsScreenReadable = ($element.is(config._options._focusableElements) ||
+      $element.is(config._options._readableElements)) && hasReadableContent;
     if (hasNativeFocusOrIsScreenReadable) {
       return true;
     }


### PR DESCRIPTION
fixes #92 

### Fixed
* Check for aria-label, aria-labelledby or text content before marking [role=heading] as readable