### PR TITLE
issue/95 Submit display none fix

### DIFF
--- a/js/a11y/browserFocus.js
+++ b/js/a11y/browserFocus.js
@@ -47,7 +47,7 @@ export default class BrowserFocus extends Backbone.Controller {
     }
     // Check if element losing focus is losing focus
     // due to the addition of a disabled class
-    if (!$element.is('[disabled]')) {
+    if (!$element.is('[disabled]') && $element.css('display') !== 'none' && $element.css('visibility') !== 'hidden') {
       return;
     }
     // Move focus to next readable element

--- a/js/views/buttonsView.js
+++ b/js/views/buttonsView.js
@@ -55,7 +55,7 @@ export default class ButtonsView extends Backbone.View {
       return;
     }
 
-    this.$('.js-btn-marking').removeClass('is-incorrect is-correct').addClass('u-display-none');
+    this.$('.js-btn-marking, .js-btn-marking-label').removeClass('is-incorrect is-correct').addClass('u-display-none');
     this.$el.removeClass('is-submitted');
     this.model.set('feedbackMessage', undefined);
     a11y.toggleEnabled(this.$('.js-btn-feedback'), false);
@@ -122,7 +122,7 @@ export default class ButtonsView extends Backbone.View {
 
     this.$('.js-btn-action').toggleClass('is-full-width', !canShowFeedback);
     this.$('.js-btn-feedback').toggleClass('u-display-none', !canShowFeedback);
-    this.$('.js-btn-marking').toggleClass('is-full-width u-display-none', !canShowFeedback);
+    this.$('.js-btn-marking, .js-btn-marking-label').toggleClass('is-full-width u-display-none', !canShowFeedback);
   }
 
   updateAttemptsCount() {
@@ -165,10 +165,19 @@ export default class ButtonsView extends Backbone.View {
     const isCorrect = this.model.get('_isCorrect');
     const ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
 
-    this.$('.js-btn-marking')
+    const $marking = this.$('.js-btn-marking, .js-btn-marking-label')
       .removeClass('u-display-none')
-      .addClass(isCorrect ? 'is-correct' : 'is-incorrect')
-      .attr('aria-label', isCorrect ? ariaLabels.answeredCorrectly : ariaLabels.answeredIncorrectly);
+      .addClass(isCorrect ? 'is-correct' : 'is-incorrect');
+
+    const $ariaLabel = this.$('.js-btn-marking-label');
+    const hasSpanAriaLabel = Boolean($ariaLabel.length);
+    if (!hasSpanAriaLabel) {
+      // Backward compability
+      $marking.attr('aria-label', isCorrect ? ariaLabels.answeredCorrectly : ariaLabels.answeredIncorrectly);
+      return;
+    }
+
+    $ariaLabel.html(isCorrect ? ariaLabels.answeredCorrectly : ariaLabels.answeredIncorrectly);
   }
 
   refresh() {

--- a/templates/buttons.hbs
+++ b/templates/buttons.hbs
@@ -1,6 +1,6 @@
 <div class="btn__response-container">
 
-  <div class="btn__marking js-btn-marking u-display-none" aria-label="{{#all _isInteractionComplete _canShowMarking}}{{#if _isCorrect}}{{@root/_globals._accessibility._ariaLabels.answeredCorrectly}}{{else}}{{@root/_globals._accessibility._ariaLabels.answeredIncorrectly}}{{/if}}{{/all}}">
+  <div class="btn__marking js-btn-marking u-display-none">
     <div class="icon" aria-hidden="true"></div>
   </div>
 
@@ -11,6 +11,8 @@
   <button class="btn-text btn__action js-btn-action" aria-label="{{_buttons._submit.ariaLabel}}">
     {{{_buttons._submit.buttonText}}}
   </button>
+  
+  <span class="js-btn-marking-label aria-label u-display-none">{{#all _isInteractionComplete _canShowMarking}}{{#if _isCorrect}}{{@root/_globals._accessibility._ariaLabels.answeredCorrectly}}{{else}}{{@root/_globals._accessibility._ariaLabels.answeredIncorrectly}}{{/if}}{{/all}}</span>
 
   <button class="btn-text btn__feedback js-btn-feedback is-disabled" aria-label="{{_buttons._showFeedback.ariaLabel}}" aria-disabled="true">
     {{{_buttons._showFeedback.buttonText}}}


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/3190
fixes #95 

The focus now moves forward to the marking aria label if the button goes missing.

### Fixed
* Moved the marking aria label to after the submit button to make it readable [3190](https://github.com/adaptlearning/adapt_framework/issues/3190)
* Blur handler now checks for `display: none` and `visibility: hidden` as well as the `[disabled]` attribute