### PR TITLE
issue/106 Fix missing helper

### DIFF
--- a/templates/header.jsx
+++ b/templates/header.jsx
@@ -43,8 +43,7 @@ export default function Header(props) {
     // If no title, displaytitle, body or instruction is specified
     // Output only the component description
     return (
-      <div className="aria-label">
-        {html(compile(ariaRegion))}
+      <div className="aria-label" dangerouslySetInnerHTML={{ __html: compile(ariaRegion) }}>
       </div>
     );
   }


### PR DESCRIPTION
fixes #106 

### Fixed
* Bug with conversion from `html` to `dangerouslySetInnerHTML`