### PR TITLE
issue/3295 New list structure in drawer

### DIFF
--- a/templates/drawer.hbs
+++ b/templates/drawer.hbs
@@ -2,7 +2,7 @@
 
   <span id="drawer-heading" class="aria-label">{{_globals._accessibility._ariaLabels.drawer}}</span>
 
-  <div class="drawer__holder js-drawer-holder"></div>
+  <div class="drawer__holder js-drawer-holder" role="list"></div>
 
   <div class="drawer__toolbar u-clearfix">
 


### PR DESCRIPTION
#3295 Making drawer__holder the list with a direct child, either a 'listitem' or 'group' depending on the current view