### PR TITLE
issue/#102 - Headings use displayTitle instead of title

### DIFF
--- a/templates/heading.hbs
+++ b/templates/heading.hbs
@@ -5,14 +5,14 @@
   <span class="aria-label">
   {{#if _isA11yCompletionDescriptionEnabled}}
     {{#if _isOptional}}
-      {{{compile title}}}
+      {{{compile displayTitle}}}
       {{else if _isComplete}}
-      {{_globals._accessibility._ariaLabels.complete}} {{{compile title}}}
+      {{_globals._accessibility._ariaLabels.complete}} {{{compile displayTitle}}}
       {{else}}
-      {{_globals._accessibility._ariaLabels.incomplete}} {{{compile title}}}
+      {{_globals._accessibility._ariaLabels.incomplete}} {{{compile displayTitle}}}
     {{/if}}
     {{else}}
-    {{{compile title}}}
+    {{{compile displayTitle}}}
   {{/if}}
   </span>
 


### PR DESCRIPTION
Adjusts so the aria-label for all headings match what is visually represented on-screen. In relation to #102.