### PR TITLE
issue/126 Fixes notify accessibility blocking

### DIFF
--- a/js/views/notifyPopupView.js
+++ b/js/views/notifyPopupView.js
@@ -168,7 +168,7 @@ export default class NotifyPopupView extends Backbone.View {
     $.inview();
     this.hasOpened = true;
     // Allows popup manager to control focus
-    a11y.popupOpened(this.$('.notify__popup'));
+    a11y.popupOpened(this.$el);
     a11y.scrollDisable('body');
     $('html').addClass('notify');
     // Set focus to first accessible element


### PR DESCRIPTION
fixes #126 

Allows for content to be injected into the dialog, outside of the content, and still be accessible

### Changed
* Block accessibillity from `.notify__popup` parent, the dialog container, rather than the `.notify__popup` as the dialog content