### PR TITLE
Convert image.jsx divs to spans

### DIFF
--- a/templates/image.jsx
+++ b/templates/image.jsx
@@ -24,7 +24,7 @@ export default function Image(props) {
   if (!hasSource) return null;
   const attributionClassNamePrefixes = (props.attributionClassNamePrefixes || props.classNamePrefixes);
   return (
-    <div
+    <span
       id={props.id}
       className={classes([
         prefixClasses(props.classNamePrefixes, ['__image-container']),
@@ -43,13 +43,13 @@ export default function Image(props) {
       />
 
       {props.attribution &&
-      <div className={prefixClasses(attributionClassNamePrefixes, ['__attribution'])}>
-        <div className={prefixClasses(attributionClassNamePrefixes, ['__attribution-inner'])}>
+      <span className={prefixClasses(attributionClassNamePrefixes, ['__attribution'])}>
+        <span className={prefixClasses(attributionClassNamePrefixes, ['__attribution-inner'])}>
           {html(props.attribution)}
-        </div>
-      </div>
+        </span>
+      </span>
       }
 
-    </div>
+    </span>
   );
 }


### PR DESCRIPTION
Resolves https://github.com/adaptlearning/adapt-contrib-core/issues/132

* Converts image container divs to spans

Dependency:

https://github.com/adaptlearning/adapt-contrib-gmcq/pull/150
https://github.com/adaptlearning/adapt-contrib-vanilla/pull/333