### PR TITLE
Convert drawer button divs to spans

### DIFF
--- a/less/core/drawerItem.less
+++ b/less/core/drawerItem.less
@@ -2,4 +2,9 @@
   &__item-btn {
     width: 100%;
   }
+  
+  &__item-title,
+  &__item-body {
+    display: block;
+  }
 }

--- a/templates/drawer.hbs
+++ b/templates/drawer.hbs
@@ -8,13 +8,13 @@
 
     <div class="drawer__back">
       <button class="btn-icon drawer__btn drawer__back-btn js-drawer-back-btn" aria-label="{{_globals._accessibility._ariaLabels.previous}}">
-        <div class="icon"></div>
+        <span class="icon"></span>
       </button>
     </div>
 
     <div class="drawer__close">
       <button class="btn-icon drawer__btn drawer__close-btn js-drawer-close-btn" aria-label="{{_globals._accessibility._ariaLabels.closeDrawer}}">
-        <div class="icon"></div>
+        <span class="icon"></span>
       </button>
     </div>
 

--- a/templates/drawerItem.hbs
+++ b/templates/drawerItem.hbs
@@ -2,19 +2,19 @@
   <button class="drawer__menu-btn drawer__item-btn{{#if className}} {{className}}{{/if}}">
 
     {{#if title}}
-    <div class="drawer__menu-title drawer__item-title">
-      <div class="drawer__menu-title-inner drawer__item-title-inner">
+    <span class="drawer__menu-title drawer__item-title">
+      <span class="drawer__menu-title-inner drawer__item-title-inner">
         {{{title}}}
-      </div>
-    </div>
+      </span>
+    </span>
     {{/if}}
 
     {{#if description}}
-    <div class="drawer__menu-body drawer__item-body">
-      <div class="drawer__menu-body-inner drawer__item-body-inner">
+    <span class="drawer__menu-body drawer__item-body">
+      <span class="drawer__menu-body-inner drawer__item-body-inner">
         {{{description}}}
-      </div>
-    </div>
+      </span>
+    </span>
     {{/if}}
 
   </button>


### PR DESCRIPTION
Resolves https://github.com/adaptlearning/adapt-contrib-core/issues/134

* Converted divs to spans in drawer.hbs
* Converted divs to spans in drawerItem.hbs
* Added `display: block;` to `drawer__item-title` and `drawer__item-body` elements to restore their previous visual display