### PR TITLE
issue/3305 Support for alternative course folder name

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -48,7 +48,7 @@ class Data extends AdaptCollection {
   }
 
   loadConfigData() {
-    Adapt.config = new ConfigModel(null, { url: 'course/config.' + Adapt.build.get('jsonext'), reset: true });
+    Adapt.config = new ConfigModel(null, { url: Adapt.build.get('coursedir') + '/config.' + Adapt.build.get('jsonext'), reset: true });
     this.listenToOnce(Adapt, 'configModel:loadCourseData', this.onLoadCourseData);
     this.listenTo(Adapt.config, {
       'change:_activeLanguage': this.onLanguageChange,
@@ -93,7 +93,7 @@ class Data extends AdaptCollection {
     // All code that needs to run before adapt starts should go here
     const language = Adapt.config.get('_activeLanguage');
 
-    const courseFolder = 'course/' + language + '/';
+    const courseFolder = Adapt.build.get('coursedir') + '/' + language + '/';
 
     $('html').attr('lang', language);
 


### PR DESCRIPTION
part of https://github.com/adaptlearning/adapt_framework/issues/3305

### Added
* Support for `course` directory name to be received from grunt through the build.min.js file

### Testing
1. To change the folder from `course` to `alternative` and test out the code
```sh
git clone https://github.com/adaptlearning/adapt_framework 3305-course
cd 3305-course
git checkout issue/3305
mv src/course src/alternative
adapt devinstall && npm install
cd src/core
git checkout issue/3305
cd ../../
grunt dev --coursedir=alternative
```
2. You will need to find and replace all of the images in the json files from `course/` to `alternative/`