### PR TITLE
issue/99 Removed unnecessary labelledby on main region

### DIFF
--- a/js/views/contentObjectView.js
+++ b/js/views/contentObjectView.js
@@ -7,8 +7,7 @@ export default class ContentObjectView extends AdaptView {
 
   attributes() {
     return AdaptView.resultExtend('attributes', {
-      role: 'main',
-      'aria-labelledby': `${this.model.get('_id')}-heading`
+      role: 'main'
     }, this);
   }
 


### PR DESCRIPTION
fixes #99 

### Removed
* `aria-labelledby` on main region as it causes the screen reader to unnecessarily read the page heading multiple times in different contexts