### PR TITLE
Added browser support override ability to course config ('targets')

### DIFF
--- a/schema/config.model.schema
+++ b/schema/config.model.schema
@@ -439,7 +439,7 @@
         "strictMode": {
           "type": "boolean",
           "default": true,
-          "required": true,
+          "required": false,
           "inputType": "Checkbox",
           "validators": [],
           "title": "Use strict mode?",

--- a/schema/config.model.schema
+++ b/schema/config.model.schema
@@ -443,7 +443,7 @@
           "inputType": "Checkbox",
           "validators": [],
           "title": "Use strict mode?",
-          "help": "Uses ES6 modules. If AMD-style module definitions are required for plugins, turn this off"
+          "help": "Strict mode drops suport for AMD-style module definitions. If these are still required for any plugins, turn this setting off"
         },
         "targets": {
           "type": "string",

--- a/schema/config.model.schema
+++ b/schema/config.model.schema
@@ -443,14 +443,14 @@
           "inputType": "Checkbox",
           "validators": [],
           "title": "Use strict mode?"
+        },
+        "targets": {
+          "type": "string",
+          "title": "Supported browsers override",
+          "help": "Set the browsers that are supported. Overwrites the framework defaults if not empty. Current defaults are: 'last 2 chrome versions, last 2 firefox versions, last 2 safari versions, last 2 edge versions, last 2 ios_saf versions, last 2 and_chr versions, firefox esr'",
+          "default": ""
         }
       }
-    },
-    "targets": {
-      "type": "string",
-      "title": "Supported browsers override",
-      "description": "Set the browsers that are supported. Overrides the framework defaults if not empty",
-      "default": ""
     }
   }
 }

--- a/schema/config.model.schema
+++ b/schema/config.model.schema
@@ -432,6 +432,20 @@
       "type": "objectid",
       "required": false
     },
+    "build": {
+      "type": "object",
+      "title": "Support for setting the course build type",
+      "properties" : {
+        "strictMode": {
+          "type": "boolean",
+          "default": true,
+          "required": true,
+          "inputType": "Checkbox",
+          "validators": [],
+          "title": "Use strict mode?"
+        }
+      }
+    },
     "targets": {
       "type": "string",
       "title": "Supported browsers override",

--- a/schema/config.model.schema
+++ b/schema/config.model.schema
@@ -446,9 +446,12 @@
         },
         "targets": {
           "type": "string",
+          "required": false,
+          "default": "",
+          "inputType": "Text",
           "title": "Supported browsers override",
-          "help": "Set the browsers that are supported. Overwrites the framework defaults if not empty. Current defaults are: 'last 2 chrome versions, last 2 firefox versions, last 2 safari versions, last 2 edge versions, last 2 ios_saf versions, last 2 and_chr versions, firefox esr'",
-          "default": ""
+          "validators": [],
+          "help": "Set the browsers that are supported. Overwrites the framework defaults if not empty. Current defaults are: 'last 2 chrome versions, last 2 firefox versions, last 2 safari versions, last 2 edge versions, last 2 ios_saf versions, last 2 and_chr versions, firefox esr'"
         }
       }
     }

--- a/schema/config.model.schema
+++ b/schema/config.model.schema
@@ -443,7 +443,7 @@
           "inputType": "Checkbox",
           "validators": [],
           "title": "Use strict mode?",
-          "help": "Strict mode drops suport for AMD-style module definitions. If these are still required for any plugins, turn this setting off"
+          "help": "Strict mode improves performance by tightly restricting the declaration of variables inside code blocks and closures which may cause some older code to stop working. Please leave this at true unless you are experiencing issue with old plugins or third party libraries."
         },
         "targets": {
           "type": "string",

--- a/schema/config.model.schema
+++ b/schema/config.model.schema
@@ -431,6 +431,12 @@
     "_themePreset": {
       "type": "objectid",
       "required": false
+    },
+    "targets": {
+      "type": "string",
+      "title": "Supported browsers override",
+      "description": "Set the browsers that are supported. Overrides the framework defaults if not empty",
+      "default": ""
     }
   }
 }

--- a/schema/config.model.schema
+++ b/schema/config.model.schema
@@ -442,7 +442,8 @@
           "required": true,
           "inputType": "Checkbox",
           "validators": [],
-          "title": "Use strict mode?"
+          "title": "Use strict mode?",
+          "help": "Uses ES6 modules. If AMD-style module definitions are required for plugins, turn this off"
         },
         "targets": {
           "type": "string",

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -390,7 +390,7 @@
           "default": true,
           "inputType": "Checkbox",
           "title": "Use strict mode?",
-          "description": "Strict mode drops suport for AMD-style module definitions. If these are still required for any plugins, turn this setting off"
+          "description": "Strict mode improves performance by tightly restricting the declaration of variables inside code blocks and closures which may cause some older code to stop working. Please leave this at true unless you are experiencing issue with old plugins or third party libraries."
         },
         "targets": {
           "type": "string",

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -405,6 +405,12 @@
       "type": "string",
       "isObjectId": true,
       "title": "Theme preset"
+    },
+    "targets": {
+      "type": "string",
+      "title": "Supported browsers override",
+      "description": "Set the browsers that are supported. Overrides the framework defaults if not empty",
+      "default": ""
     }
   }
 }

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -383,7 +383,6 @@
     "build": {
       "type": "object",
       "title": "Support for setting the course build type",
-      "required": ["strictMode"],
       "properties" : {
         "strictMode": {
           "type": "boolean",

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -406,6 +406,20 @@
       "isObjectId": true,
       "title": "Theme preset"
     },
+    "build": {
+      "type": "object",
+      "title": "Support for setting the course build type",
+      "properties" : {
+        "strictMode": {
+          "type": "boolean",
+          "default": true,
+          "required": true,
+          "inputType": "Checkbox",
+          "validators": [],
+          "title": "Use strict mode?"
+        }
+      }
+    },
     "targets": {
       "type": "string",
       "title": "Supported browsers override",

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -383,14 +383,14 @@
     "build": {
       "type": "object",
       "title": "Support for setting the course build type",
+      "required": ["strictMode"],
       "properties" : {
         "strictMode": {
           "type": "boolean",
           "default": true,
-          "required": true,
           "inputType": "Checkbox",
-          "validators": [],
-          "title": "Use strict mode?"
+          "title": "Use strict mode?",
+          "description": "Uses ES6 modules. If AMD-style module definitions are required for plugins, turn this off"
         },
         "targets": {
           "type": "string",

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -417,14 +417,14 @@
           "inputType": "Checkbox",
           "validators": [],
           "title": "Use strict mode?"
+        },
+        "targets": {
+          "type": "string",
+          "title": "Supported browsers override",
+          "description": "Set the browsers that are supported. Overwrites the framework defaults if not empty. Current defaults are: 'last 2 chrome versions, last 2 firefox versions, last 2 safari versions, last 2 edge versions, last 2 ios_saf versions, last 2 and_chr versions, firefox esr'",
+          "default": ""
         }
       }
-    },
-    "targets": {
-      "type": "string",
-      "title": "Supported browsers override",
-      "description": "Set the browsers that are supported. Overrides the framework defaults if not empty",
-      "default": ""
     }
   }
 }

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -390,7 +390,7 @@
           "default": true,
           "inputType": "Checkbox",
           "title": "Use strict mode?",
-          "description": "Uses ES6 modules. If AMD-style module definitions are required for plugins, turn this off"
+          "description": "Strict mode drops suport for AMD-style module definitions. If these are still required for any plugins, turn this setting off"
         },
         "targets": {
           "type": "string",


### PR DESCRIPTION
fixes [#3312](https://github.com/adaptlearning/adapt_framework/issues/3312)

Allow a 'target' setting on course config to override desired browser compatibility