### PR TITLE
Add _friendlyId field

### DIFF
--- a/schema/content.schema.json
+++ b/schema/content.schema.json
@@ -10,6 +10,11 @@
       "type": "string",
       "title": "Type"
     },
+    "_friendlyId": {
+      "type": "string",
+      "title": "Friendly id",
+      "description": "A human-readable ID for this content object which will replace the standard _id field on course build (useful in instances where the _id must be specified in the config of an extension). Must be unique to this course."
+    },
     "_parentId": {
       "type": "string",
       "isObjectId": true,


### PR DESCRIPTION
Fixes #160 

This is a new human-readable ID for content objects which will replace the standard `_id` field on course build (useful in instances where the `_id` must be specified in the config of an extension, and is otherwise broken when the course is copied/imported elsewhere).