### PR TITLE
issue/123 Moved skip navigation button onscreen

### DIFF
--- a/less/core/nav.less
+++ b/less/core/nav.less
@@ -18,17 +18,18 @@
   &__skip-btn {
     position: absolute;
     left: 0;
-    margin-top: 0;
-    top: -100%;
+    top: 0;
     z-index: 100;
-    .transition(top @duration ease-in-out);
 
     html:not(.has-accessibility) & {
       .u-display-none;
     }
 
-    &:focus {
-      top: 0;
+    &:not(:focus) {
+      height: 0;
+      padding: 0;
+      margin: 0;
+      overflow: hidden;
     }
   }
 


### PR DESCRIPTION
fixes #123

### Fixed
* Keep skip navigation button onscreen rather than moving it off top. This stops screen readers from scrolling up when the button receives focus