### PR TITLE
New: Added accessible alert api (fixes #181)

### DIFF
--- a/js/views/notifyPushView.js
+++ b/js/views/notifyPushView.js
@@ -3,8 +3,11 @@ import Adapt from 'core/js/adapt';
 export default class NotifyPushView extends Backbone.View {
 
   className() {
-    let classes = 'notify-push ';
-    classes += (this.model.get('_classes') || '');
+    const classes = [
+      'notify-push',
+      this.model.get('_classes'),
+      this.model.get('_type') === 'a11y-push' && 'aria-label'
+    ].filter(Boolean).join('.');
     return classes;
   }
 

--- a/js/views/notifyView.js
+++ b/js/views/notifyView.js
@@ -25,7 +25,7 @@ export default class NotifyView extends Backbone.View {
   get stack() {
     return this._stack;
   }
-  
+
   get isOpen() {
     return (this.stack.length > 0);
   }
@@ -49,9 +49,11 @@ export default class NotifyView extends Backbone.View {
       _closeOnShadowClick: true
     });
 
-    if (notifyObject._type === 'push') {
-      this.notifyPushes.push(notifyObject);
-      return;
+    switch (notifyObject._type) {
+      case 'a11y-push':
+      case 'push':
+        this.notifyPushes.push(notifyObject);
+        return;
     }
 
     return new NotifyPopupView({

--- a/templates/notify.hbs
+++ b/templates/notify.hbs
@@ -1,4 +1,4 @@
 <div class="notify__container-inner">
-  <div class="notify__push-container" aria-live="assertive" aria-atomic="true"></div>
   <div class="notify__popup-container"></div>
+  <div class="notify__push-container a11y-ignore" aria-live="assertive" aria-atomic="true"></div>
 </div>


### PR DESCRIPTION
fixes #181 

### Added
* Notify create `a11y-push` using `notify.create({ _type: 'a11y-push', body: 'Read me as an alert' })` to provide screen reader alerts

### Fixed
* Made toast notifications appear above normal notify