### PR TITLE
Update: provide alternative heading for AT (fixes #173)

### DIFF
--- a/js/models/questionModel.js
+++ b/js/models/questionModel.js
@@ -287,9 +287,14 @@ class QuestionModel extends ComponentModel {
     const body = (this.get('_attemptsLeft') && feedback.notFinal) || feedback.final;
 
     this.set({
+      altFeedbackTitle: this.getAltFeedbackTitle(),
       feedbackTitle: this.getFeedbackTitle(),
       feedbackMessage: Handlebars.compile(body)(this.toJSON())
     });
+  }
+
+  getAltFeedbackTitle() {
+    return this.get('_feedback').altTitle || Adapt.course.get('_globals')._accessibility.altFeedbackTitle || '';
   }
 
   getFeedbackTitle() {

--- a/templates/notifyPopup.hbs
+++ b/templates/notifyPopup.hbs
@@ -20,11 +20,13 @@
           </div>
         </div>
         {{else}}
-        <div class="notify__title aria-label" id="notify-heading">
-          <div class="notify__title-inner" {{{a11y_attrs_heading 'notify'}}}>
-            {{{compile altTitle}}}
+          {{#if altTitle}}
+          <div class="notify__title aria-label" id="notify-heading">
+            <div class="notify__title-inner" {{{a11y_attrs_heading 'notify'}}}>
+              {{{compile altTitle}}}
+            </div>
           </div>
-        </div>
+          {{/if}}
         {{/if}}
 
         {{#if body}}

--- a/templates/notifyPopup.hbs
+++ b/templates/notifyPopup.hbs
@@ -19,14 +19,12 @@
             {{{compile title}}}
           </div>
         </div>
-        {{else}}
-          {{#if altTitle}}
+        {{else if altTitle}}
           <div class="notify__title aria-label" id="notify-heading">
             <div class="notify__title-inner" {{{a11y_attrs_heading 'notify'}}}>
               {{{compile altTitle}}}
             </div>
           </div>
-          {{/if}}
         {{/if}}
 
         {{#if body}}

--- a/templates/notifyPopup.hbs
+++ b/templates/notifyPopup.hbs
@@ -19,6 +19,12 @@
             {{{compile title}}}
           </div>
         </div>
+        {{else}}
+        <div class="notify__title aria-label" id="notify-heading">
+          <div class="notify__title-inner" {{{a11y_attrs_heading 'notify'}}}>
+            {{{compile altTitle}}}
+          </div>
+        </div>
         {{/if}}
 
         {{#if body}}

--- a/templates/notifyPopup.hbs
+++ b/templates/notifyPopup.hbs
@@ -21,7 +21,7 @@
         </div>
         {{else if altTitle}}
           <div class="notify__title aria-label" id="notify-heading">
-            <div class="notify__title-inner" {{{a11y_attrs_heading 'notify'}}}>
+            <div class="notify__title-inner" role="heading" aria-level="{{a11y_aria_level _id 'notify' _ariaLevel}}">
               {{{compile altTitle}}}
             </div>
           </div>


### PR DESCRIPTION
[//]: # (Link the PR to the original issue)
fixes https://github.com/adaptlearning/adapt-contrib-core/issues/173

### Update
* Provide an alternative heading for Assistive Technology if no visual heading is required
