### PR TITLE
Fix: replace deprecated a11y_attrs_heading usage (fixes #202)

### DIFF
--- a/templates/notifyPopup.hbs
+++ b/templates/notifyPopup.hbs
@@ -19,6 +19,12 @@
             {{{compile title}}}
           </div>
         </div>
+        {{else if altTitle}}
+          <div class="notify__title aria-label" id="notify-heading">
+            <div class="notify__title-inner" role="heading" aria-level="{{a11y_aria_level _id 'notify' _ariaLevel}}">
+              {{{compile altTitle}}}
+            </div>
+          </div>
         {{/if}}
 
         {{#if body}}

--- a/templates/notifyPopup.hbs
+++ b/templates/notifyPopup.hbs
@@ -19,12 +19,6 @@
             {{{compile title}}}
           </div>
         </div>
-        {{else if altTitle}}
-          <div class="notify__title aria-label" id="notify-heading">
-            <div class="notify__title-inner" role="heading" aria-level="{{a11y_aria_level _id 'notify' _ariaLevel}}">
-              {{{compile altTitle}}}
-            </div>
-          </div>
         {{/if}}
 
         {{#if body}}

--- a/templates/notifyPopup.hbs
+++ b/templates/notifyPopup.hbs
@@ -15,7 +15,7 @@
 
         {{#if title}}
         <div class="notify__title" id="notify-heading">
-          <div class="notify__title-inner" {{{a11y_attrs_heading 'notify'}}}>
+          <div class="notify__title-inner" role="heading" aria-level="{{a11y_aria_level _id 'notify' _ariaLevel}}">
             {{{compile title}}}
           </div>
         </div>

--- a/templates/notifyPush.hbs
+++ b/templates/notifyPush.hbs
@@ -5,7 +5,7 @@
 
   {{#if title}}
   <div class="notify-push__title">
-    <div class="notify-push__title-inner" {{{a11y_attrs_heading 'notify'}}}>
+    <div class="notify-push__title-inner" role="heading" aria-level="{{a11y_aria_level _id 'notify' _ariaLevel}}">
       {{{compile title}}}
     </div>
   </div>


### PR DESCRIPTION
#202 

### Fix
* replace deprecated a11y_attrs_heading usage

[//]: # (Mention any other dependencies)
See https://github.com/adaptlearning/adapt-contrib-tutor/compare/issue/67

