### PR TITLE
Update: Adds context to status indicators (fixes #151)

### DIFF
--- a/templates/heading.hbs
+++ b/templates/heading.hbs
@@ -7,9 +7,9 @@
     {{#if _isOptional}}
       {{{compile title}}}
       {{else if _isComplete}}
-      {{#equals _type "menu"}}{{_globals._accessibility._ariaLabels.course}} {{/equals}}{{#equals _type "page"}}{{_globals._accessibility._ariaLabels.contentObject}} {{/equals}}{{#equals _type "article"}}{{_globals._accessibility._ariaLabels.article}} {{/equals}}{{#equals _type "block"}}{{_globals._accessibility._ariaLabels.block}} {{/equals}}{{#equals _type "component"}}{{_globals._accessibility._ariaLabels.component}} {{/equals}}{{_globals._accessibility._ariaLabels.complete}}. {{{compile title}}}
+      {{_globals._accessibility._ariaLabels.complete}}. {{{compile title}}}
       {{else}}
-      {{#equals _type "menu"}}{{_globals._accessibility._ariaLabels.course}} {{/equals}}{{#equals _type "page"}}{{_globals._accessibility._ariaLabels.contentObject}} {{/equals}}{{#equals _type "article"}}{{_globals._accessibility._ariaLabels.article}} {{/equals}}{{#equals _type "block"}}{{_globals._accessibility._ariaLabels.block}} {{/equals}}{{#equals _type "component"}}{{_globals._accessibility._ariaLabels.component}} {{/equals}}{{_globals._accessibility._ariaLabels.incomplete}}. {{{compile title}}}
+      {{_globals._accessibility._ariaLabels.incomplete}}. {{{compile title}}}
     {{/if}}
     {{else}}
     {{{compile title}}}

--- a/templates/heading.hbs
+++ b/templates/heading.hbs
@@ -7,9 +7,9 @@
     {{#if _isOptional}}
       {{{compile title}}}
       {{else if _isComplete}}
-      {{{compile title}}} ({{_globals._accessibility._ariaLabels.complete}})
+      {{#equals _type "menu"}}{{_globals._accessibility._ariaLabels.course}} {{/equals}}{{#equals _type "page"}}{{_globals._accessibility._ariaLabels.contentObject}} {{/equals}}{{#equals _type "article"}}{{_globals._accessibility._ariaLabels.article}} {{/equals}}{{#equals _type "block"}}{{_globals._accessibility._ariaLabels.block}} {{/equals}}{{#equals _type "component"}}{{_globals._accessibility._ariaLabels.component}} {{/equals}}{{_globals._accessibility._ariaLabels.complete}}. {{{compile title}}}
       {{else}}
-      {{{compile title}}} ({{_globals._accessibility._ariaLabels.incomplete}})
+      {{#equals _type "menu"}}{{_globals._accessibility._ariaLabels.course}} {{/equals}}{{#equals _type "page"}}{{_globals._accessibility._ariaLabels.contentObject}} {{/equals}}{{#equals _type "article"}}{{_globals._accessibility._ariaLabels.article}} {{/equals}}{{#equals _type "block"}}{{_globals._accessibility._ariaLabels.block}} {{/equals}}{{#equals _type "component"}}{{_globals._accessibility._ariaLabels.component}} {{/equals}}{{_globals._accessibility._ariaLabels.incomplete}}. {{{compile title}}}
     {{/if}}
     {{else}}
     {{{compile title}}}


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Update
* Status indicators in the aria-label should come first. Additionally, without context as to what is the status is reporting on can cause confusion as to the purpose of the status indicators. It was agreed the best path forward was to present all aria-headers in the following format:
* [context (if applicable)] [status]. [title]

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Grab latest PR
2. Grab latest PR from course.json updates https://github.com/adaptlearning/adapt_framework/pull/3320

[//]: # (Mention any other dependencies)
Requires you to add adjustments to course.json aria-labels. https://github.com/adaptlearning/adapt_framework/pull/3320
