### PR TITLE
Fix: Add _shouldRenderId to notify api (fixes #208)

### DIFF
--- a/js/views/notifyPopupView.js
+++ b/js/views/notifyPopupView.js
@@ -177,7 +177,7 @@ export default class NotifyPopupView extends Backbone.View {
 
   async addSubView() {
     this.subView = this.model.get('_view');
-    if (this.model.get('_id')) {
+    if (this.model.get('_id') && this.model.get('_shouldRenderId') !== false) {
       // Automatically render the specified id
       const model = data.findById(this.model.get('_id'));
       const View = components.getViewClass(model);

--- a/js/views/notifyPopupView.js
+++ b/js/views/notifyPopupView.js
@@ -177,7 +177,7 @@ export default class NotifyPopupView extends Backbone.View {
 
   async addSubView() {
     this.subView = this.model.get('_view');
-    if (this.model.get('_id') && this.model.get('_shouldRenderId') !== false) {
+    if (this.model.get('_shouldRenderId') && this.model.get('_id')) {
       // Automatically render the specified id
       const model = data.findById(this.model.get('_id'));
       const View = components.getViewClass(model);

--- a/js/views/notifyView.js
+++ b/js/views/notifyView.js
@@ -25,7 +25,7 @@ export default class NotifyView extends Backbone.View {
   get stack() {
     return this._stack;
   }
-  
+
   get isOpen() {
     return (this.stack.length > 0);
   }
@@ -44,6 +44,7 @@ export default class NotifyView extends Backbone.View {
   create(notifyObject, defaults) {
     notifyObject = _.defaults({}, notifyObject, defaults, {
       _type: 'popup',
+      _shouldRenderId: false,
       _isCancellable: true,
       _showCloseButton: true,
       _closeOnShadowClick: true


### PR DESCRIPTION
fixes #208

### Fix
* Notify should not render the subview specified by the `_id` unless `_shouldRenderId = true`
