### PR TITLE
Refactored branch issue/193

### DIFF
--- a/js/drawer.js
+++ b/js/drawer.js
@@ -1,5 +1,6 @@
 import Adapt from 'core/js/adapt';
 import DrawerView from 'core/js/views/drawerView';
+import tooltips from './tooltips';
 
 const DrawerCollection = new Backbone.Collection(null, { comparator: 'drawerOrder' });
 const Drawer = {};
@@ -18,6 +19,10 @@ Drawer.triggerCustomView = function(view, hasBackButton) {
 
 Adapt.on({
   'adapt:start'() {
+    tooltips.register({
+      _id: 'drawer',
+      ...Adapt.course.get('_globals')?._extensions?._drawer?._navTooltip || {}
+    });
     new DrawerView({ collection: DrawerCollection });
   },
   'app:languageChanged'() {

--- a/js/tooltips.js
+++ b/js/tooltips.js
@@ -11,8 +11,14 @@ class TooltipController extends Backbone.Controller {
     _.bindAll(this, 'onMouseOver');
     this._tooltipData = {};
     this._currentId = null;
-    this.attachToBody();
     this.listenTo(Adapt, 'adapt:preInitialize', this.onAdaptPreInitialize);
+  }
+
+  onAdaptPreInitialize() {
+    const config = this.getConfig();
+    if (config?._isEnabled === false) return;
+    this.attachToBody();
+    $(document).on('mouseover', '*', this.onMouseOver);
   }
 
   attachToBody() {
@@ -20,12 +26,6 @@ class TooltipController extends Backbone.Controller {
     const $el = this.tooltipsView.$el;
     if ($el[0].parentNode && $el.is(':last-child')) return;
     $el.appendTo('body');
-  }
-
-  onAdaptPreInitialize() {
-    const config = this.getConfig();
-    if (config?._isEnabled === false) return;
-    $(document).off('mouseover', '*', this.onMouseOver);
   }
 
   getConfig() {

--- a/js/tooltips.js
+++ b/js/tooltips.js
@@ -8,129 +8,83 @@ import Backbone from 'backbone';
 class TooltipController extends Backbone.Controller {
 
   initialize() {
-    _.bindAll(this, 'onMouseOver', 'onMouseOut');
-    this._tooltipData = [];
-    this._containerView = new TooltipContainerView();
-    this._containerView.$el.appendTo('body');
+    _.bindAll(this, 'onMouseOver');
+    this._tooltipData = {};
+    this._currentId = null;
+    this.attachToBody();
     this.listenTo(Adapt, 'adapt:preInitialize', this.onAdaptPreInitialize);
   }
 
-  removeListener() {
-    $(document).off('mouseover', '[data-tooltip-id]', this.onMouseOver);
+  attachToBody() {
+    this.tooltipsView = this.tooltipsView || new TooltipView();
+    const $el = this.tooltipsView.$el;
+    if ($el[0].parentNode && $el.is(':last-child')) return;
+    $el.appendTo('body');
   }
 
-  addListener() {
-    this.removeListener();
-    $(document).on('mouseover', '[data-tooltip-id]', this.onMouseOver);
+  onAdaptPreInitialize() {
+    const config = this.getConfig();
+    if (config?._isEnabled === false) return;
+    $(document).off('mouseover', '*', this.onMouseOver);
   }
 
   getConfig() {
     return Adapt.course.get('_tooltips');
   }
 
-  registerGlobalTooltips() {
-    const tooltips = Adapt.course.get('_globals')?._tooltips;
-    if (!tooltips) return;
-    tooltips.forEach(tooltip => this.register(tooltip));
+  /**
+   * @param {jQuery} event
+   */
+  onMouseOver(event) {
+    // Ignore bubbled events
+    if (event.currentTarget !== event.target) return;
+    // Fetch first found tooltip element from target, through parents to html
+    const $mouseoverEl = $(event.currentTarget).parents().add(event.currentTarget).filter('[data-tooltip-id]').last();
+    const id = $mouseoverEl.data('tooltip-id');
+    // Cancel if id is already displayed
+    if (this._currentId === id) return;
+    this._currentId = id;
+    const tooltip = this.getTooltip(id);
+    if (!tooltip?.get('_isEnabled')) return this.hide();
+    this.show(tooltip, $mouseoverEl);
   }
 
+  /**
+   * @param {string} id
+   * @returns {TooltipModel}
+   */
   getTooltip(id) {
-    return this._tooltipData.find(tooltip => tooltip.get('_id') === id);
-  }
-
-  register(data) {
-    const tooltip = this.getTooltip();
-    if (tooltip) {
-      logging.warn(`Tooltip with id ${tooltip._id} already registered`);
-      return;
-    }
-    this._tooltipData.push(new TooltipModel(data));
-  }
-
-  show(tooltip) {
-    this.hide();
-
-    console.log('show tooltip', tooltip.get('_id'));
-    this.tooltipsView = new TooltipView({model:tooltip, target:this.$mouseoverEl});
-    this.tooltipsView.attach('appendTo', this._containerView.$el);
-
-    if (!this._containerView.$el.is(':last-child')) {
-      this._containerView.$el.appendTo('body');
-    }
+    return this._tooltipData[id];
   }
 
   hide() {
-    if (!this.tooltipsView) return;
-
-    console.log('hide tooltip', this.tooltipsView.model.get('_id'));
-
-    if (this.$mouseoverEl[0] === this.tooltipsView.$target[0]) {
-      // mouse has left current tooltip target and not entered another
-      this.$mouseoverEl = this.$prevMouseoverEl = null;
-    }
-
-    this.tooltipsView.$target.off('mouseout', this.onMouseOut);
-
-    this.tooltipsView.remove();
-    this.tooltipsView = null;
+    this._currentId = null;
+    this.tooltipsView.hide();
   }
 
-  checkShouldHide() {
-    if (this.shouldIgnoreMouseout) {
-      this.shouldIgnoreMouseout = false;
-      return;
-    }
-
-    this.hide();
+  /**
+   * @param {TooltipModel} tooltip
+   * @param {jQuery} $mouseoverEl
+   */
+  show(tooltip, $mouseoverEl) {
+    this.attachToBody();
+    this.tooltipsView.show(tooltip, $mouseoverEl);
   }
 
-  onAdaptPreInitialize() {
-    this.registerGlobalTooltips();
-
-    const config = this.getConfig();
-
-    if (!config || config._isEnabled !== false) {
-      this.addListener();
-    }
+  /**
+   * @param {Object} tooltipData
+   * @param {boolean} tooltipData._isEnabled
+   * @param {string} tooltipData._id Id of registered tooltip text
+   * @param {string} tooltipData.text Text to be displayed
+   * @returns
+   */
+  register(tooltipData) {
+    if (!tooltipData._id) return logging.warn('Tooltip cannot be registered with no id');
+    const existingTooltip = Boolean(this.getTooltip(tooltipData._id));
+    if (existingTooltip) return logging.warn(`Tooltip with id ${existingTooltip._id} already registered`);
+    this._tooltipData[tooltipData._id] = new TooltipModel(tooltipData);
   }
 
-  onMouseOver(e) {
-    this.$prevMouseoverEl = this.$mouseoverEl;
-
-    this.$mouseoverEl = $(e.currentTarget);
-
-    const id = this.$mouseoverEl.data('tooltip-id');
-    const tooltip = this.getTooltip(id);
-
-    if (!tooltip || !tooltip.get('_isEnabled')) {
-      return;
-    };
-
-    // ignore mouseover descendant elements
-    if (this.$mouseoverEl[0] === this.$prevMouseoverEl?.[0]) {
-      this.shouldIgnoreMouseout = true;
-      return;
-    }
-
-    // ensure we remove any previous listener
-    if (this.$prevMouseoverEl) this.$prevMouseoverEl.off('mouseout', this.onMouseOut);
-
-    this.$mouseoverEl.on('mouseout', this.onMouseOut);
-
-    this.show(tooltip);
-  }
-
-  onMouseOut(e) {
-    _.defer(() => this.checkShouldHide());
-  }
-}
-
-class TooltipContainerView extends Backbone.View {
-  attributes() {
-    return {
-      'aria-live':  'assertive'
-    };
-  }
 }
 
 export default new TooltipController();

--- a/js/tooltips.js
+++ b/js/tooltips.js
@@ -21,15 +21,15 @@ class TooltipController extends Backbone.Controller {
     $(document).on('mouseover', '*', this.onMouseOver);
   }
 
+  getConfig() {
+    return Adapt.course.get('_tooltips');
+  }
+
   attachToBody() {
     this.tooltipsView = this.tooltipsView || new TooltipView();
     const $el = this.tooltipsView.$el;
     if ($el[0].parentNode && $el.is(':last-child')) return;
     $el.appendTo('body');
-  }
-
-  getConfig() {
-    return Adapt.course.get('_tooltips');
   }
 
   /**

--- a/js/tooltips.js
+++ b/js/tooltips.js
@@ -76,7 +76,6 @@ class TooltipController extends Backbone.Controller {
    * @param {boolean} tooltipData._isEnabled
    * @param {string} tooltipData._id Id of registered tooltip text
    * @param {string} tooltipData.text Text to be displayed
-   * @returns
    */
   register(tooltipData) {
     if (!tooltipData._id) return logging.warn('Tooltip cannot be registered with no id');

--- a/js/tooltips.js
+++ b/js/tooltips.js
@@ -36,7 +36,7 @@ class TooltipController extends Backbone.Controller {
    * @param {jQuery} event
    */
   onMouseOver(event) {
-    // Ignore bubbled events
+    // Ignore propagated events
     if (event.currentTarget !== event.target) return;
     // Fetch first found tooltip element from target, through parents to html
     const $mouseoverEl = $(event.currentTarget).parents().add(event.currentTarget).filter('[data-tooltip-id]').last();

--- a/js/tooltips.js
+++ b/js/tooltips.js
@@ -79,7 +79,7 @@ class TooltipController extends Backbone.Controller {
    */
   register(tooltipData) {
     if (!tooltipData._id) return logging.warn('Tooltip cannot be registered with no id');
-    const existingTooltip = Boolean(this.getTooltip(tooltipData._id));
+    const existingTooltip = this.getTooltip(tooltipData._id);
     if (existingTooltip) return logging.warn(`Tooltip with id ${existingTooltip._id} already registered`);
     this._tooltipData[tooltipData._id] = new TooltipModel(tooltipData);
   }

--- a/js/views/TooltipView.js
+++ b/js/views/TooltipView.js
@@ -1,4 +1,3 @@
-import Adapt from 'core/js/adapt';
 import { templates } from 'core/js/reactHelpers';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -7,7 +6,7 @@ export default class TooltipView extends Backbone.View {
 
   attributes() {
     return {
-      'aria-live':  'assertive'
+      'aria-live': 'assertive'
     };
   }
 
@@ -15,115 +14,77 @@ export default class TooltipView extends Backbone.View {
     return 'tooltip__container';
   }
 
-  initialize(options) {
-    this.$target = options.target;
-    this._classSet = new Set(_.result(this, 'className').trim().split(/\s+/));
-    this.listenTo(this.model, 'all', this.changed);
-    this.listenTo(Adapt, 'device:changed', this.changed);
-  }
-
-  attach(method, ...args) {
-    this.$el[method](...args);
-    this.changed();
-  }
-
-  changed(eventName = null) {
-    if (typeof eventName === 'string' && eventName.startsWith('bubble')) {
-      // Ignore bubbling events as they are outside of this view's scope
-      return;
-    }
-    const props = {
-      // Add view own properties, bound functions etc
-      ...this,
-      // Add model json data
-      ...this.model.toJSON(),
-      // Add globals
-      _globals: Adapt.course.get('_globals')
-    };
-    const Template = templates.tooltip;
-    this.updateViewProperties();
-    ReactDOM.render(<Template {...props} />, this.el);
+  /**
+   * @param {TooltipModel} tooltip
+   * @param {jQuery} $mouseoverEl
+   */
+  show(tooltip, $mouseoverEl) {
+    this.model = tooltip;
+    this.$target = $mouseoverEl;
+    this.$el.addClass('is-loading is-shown');
+    this.listenTo(this.model, 'all', this.render);
+    this.render();
     this.position();
+    this.$el.removeClass('is-loading');
   }
 
-  updateViewProperties() {
-    const classesToAdd = _.result(this, 'className').trim().split(/\s+/);
-    classesToAdd.forEach(i => this._classSet.add(i));
-    const classesToRemove = [ ...this._classSet ].filter(i => !classesToAdd.includes(i));
-    classesToRemove.forEach(i => this._classSet.delete(i));
-    this._setAttributes({ ..._.result(this, 'attributes'), id: _.result(this, 'id') });
-    this.$el.removeClass(classesToRemove).addClass(classesToAdd);
+  hide() {
+    this.stopListening(this.model);
+    this.model = null;
+    this.$target = null;
+    this.$el.removeClass('is-shown');
+  }
+
+  render() {
+    const Template = templates.tooltip;
+    ReactDOM.render(<Template {...this.model.toJSON()} />, this.el);
   }
 
   position() {
     const targetBoundingRect = this.$target[0].getBoundingClientRect();
-
-    // put the tooltip in the top left of the viewport
-    this.$el.css({
-      'left': `${$(window).scrollLeft()}px`,
-      'top': `${$(window).scrollTop()}px`
-    });
-
-    // calculate optimum position
+    // Calculate optimum position
     const availableWidth = $('html')[0].clientWidth;
     const availableHeight = $('html')[0].clientHeight;
-    const tooltipsWidth = this.$el.width();
-    const tooltipsHeight = this.$el.height();
+    const tooltipsWidth = this.$('.tooltip').width();
+    const tooltipsHeight = this.$('.tooltip').height();
     const scrollTop = $(window).scrollTop();
     const scrollLeft = $(window).scrollLeft();
-    const canAlignTop = targetBoundingRect.top - tooltipsHeight >= 0;
     const canAlignBottom = targetBoundingRect.bottom + tooltipsHeight < availableHeight;
-    const canAlignLeft = targetBoundingRect.left - tooltipsWidth >= 0;
     const canAlignRight = targetBoundingRect.right + tooltipsWidth < availableWidth;
     const canAlignBottomRight = canAlignBottom && canAlignRight;
-    const canAlignTopRight = canAlignTop && canAlignRight;
-    const canAlignBottomLeft = canAlignBottom && canAlignLeft;
-    const canAlignTopLeft = canAlignTop && canAlignLeft;
-
-    const alignBottomRight = () => {
-      //console.log('alignBottomRight');
-      this.$el.css({
-        'left': `${targetBoundingRect.right + scrollLeft}px`,
-        'top': `${targetBoundingRect.bottom + scrollTop}px`
-      });
+    function getPosition() {
+      if (!canAlignBottomRight) {
+        // Find the 'corner' with the most space from the viewport edge
+        const isTopPreferred = availableHeight - (targetBoundingRect.bottom + tooltipsHeight) < targetBoundingRect.top - tooltipsHeight;
+        const isLeftPreferred = availableWidth - (targetBoundingRect.right + tooltipsWidth) < targetBoundingRect.left - tooltipsWidth;
+        if (isTopPreferred && isLeftPreferred) {
+          // Top left
+          return {
+            left: `${targetBoundingRect.left - tooltipsWidth + scrollLeft}px`,
+            top: `${targetBoundingRect.top - tooltipsHeight + scrollTop}px`
+          };
+        }
+        if (isTopPreferred) {
+          // Top right
+          return {
+            left: `${targetBoundingRect.right + scrollLeft}px`,
+            top: `${targetBoundingRect.top - tooltipsHeight + scrollTop}px`
+          };
+        }
+        if (isLeftPreferred) {
+          // Bottom left
+          return {
+            left: `${targetBoundingRect.left - tooltipsWidth + scrollLeft}px`,
+            top: `${targetBoundingRect.bottom + scrollTop}px`
+          };
+        }
+      }
+      // Bottom right, default
+      return {
+        left: `${targetBoundingRect.right + scrollLeft}px`,
+        top: `${targetBoundingRect.bottom + scrollTop}px`
+      };
     }
-
-    const alignTopRight = () => {
-      //console.log('alignTopRight');
-      this.$el.css({
-        'left': `${targetBoundingRect.right + scrollLeft}px`,
-        'top': `${targetBoundingRect.top - tooltipsHeight + scrollTop}px`
-      });
-    }
-
-    const alignBottomLeft = () => {
-      //console.log('alignBottomLeft');
-      this.$el.css({
-        'left': `${targetBoundingRect.left - tooltipsWidth + scrollLeft}px`,
-        'top': `${targetBoundingRect.bottom + scrollTop}px`
-      });  
-    }
-
-    const alignTopLeft = () => {
-      //console.log('alignTopLeft');
-      this.$el.css({
-        'left': `${targetBoundingRect.left - tooltipsWidth + scrollLeft}px`,
-        'top': `${targetBoundingRect.top - tooltipsHeight + scrollTop}px`
-      });
-    }
-
-    if (canAlignBottomRight) return alignBottomRight();
-    if (canAlignTopRight) return alignTopRight();
-    if (canAlignBottomLeft) return alignBottomLeft();
-    if (canAlignTopLeft) return alignTopLeft();
-    
-    // find the 'corner' with the most space
-    const isTopPreferred = availableHeight - (targetBoundingRect.bottom + tooltipsHeight) < targetBoundingRect.top - tooltipsHeight;
-    const isLeftPreferred = availableWidth - (targetBoundingRect.right + tooltipsWidth) < targetBoundingRect.left - tooltipsWidth;
-
-    if (isTopPreferred && isLeftPreferred) alignTopLeft();
-    if (isTopPreferred) return alignTopRight();
-    if (isLeftPreferred) return alignBottomLeft();
-    alignBottomRight();
+    this.model.set(getPosition());
   }
 }

--- a/less/core/tooltip.less
+++ b/less/core/tooltip.less
@@ -1,4 +1,5 @@
-.tooltip__container {
+.tooltip {
+  display: none;
   position: absolute;
   top:0;
   left:0;
@@ -8,4 +9,13 @@
   min-width: 100px;
   max-width: 200px;
   z-index: 100;
+
+  &__container.is-loading & {
+    visibility: hidden;
+  }
+
+  &__container.is-shown & {
+    display: block;
+  }
+
 }

--- a/schema/course.model.schema
+++ b/schema/course.model.schema
@@ -348,6 +348,28 @@
                   "type": "number",
                   "title": "Navigation bar order",
                   "default": 0
+                },
+                "_navTooltip": {
+                  "type": "object",
+                  "title": "Navigation tooltip",
+                  "default": {},
+                  "properties": {
+                    "_isEnabled": {
+                      "type": "boolean",
+                      "default": true,
+                      "inputType": "Checkbox",
+                      "validators": [],
+                      "title": "Enabled?"
+                    },
+                    "text": {
+                      "type": "string",
+                      "title": "",
+                      "default": "Drawer button",
+                      "inputType": "Text",
+                      "required": true,
+                      "translatable": true
+                    }
+                  }
                 }
               }
             }

--- a/templates/tooltip.jsx
+++ b/templates/tooltip.jsx
@@ -3,16 +3,27 @@ import { classes, compile } from 'core/js/reactHelpers';
 
 export default function Tooltip(props) {
   const {
-    text
+    _id,
+    _classes,
+    text,
+    top,
+    left
   } = props;
 
   return (
     <div
       className={classes([
+        `tooltip-${_id}`,
+        _classes,
         'tooltip'
       ])}
-      dangerouslySetInnerHTML={{ __html: compile(text) }}
+      style={{ top, left }}
     >
+      <div
+        className='tooltip-inner'
+        dangerouslySetInnerHTML={{ __html: compile(text) }}
+      >
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Review in code

### Added
* Drawer registers its tooltip from the schema default + json config
* _classes to tooltip object and template
* JSDoc comments in the controller and view

### Simplified
* Size calculations to use a rending life-cycle of display: none, display: block, visibility: hidden and visibility: visible to allowing the size of the tooltip to be calculated before it is displayed
* Position calculations to remove duplication
* Tooltip render to update only when a new tooltip model and $target is selected
* Mouseover show/hide behaviour

### Changed
* To optional chaining operators where useful
* Tooltip store from array to object for by id index
* Position application now goes through model into jsx instead of jquery
* Linted

### Removed
* `TooltipContainerView` in favour of a permenant `TooltipView`
* Global tooltips in favour of registration only
* Blank lines
* Console logs

### Todo
* Tooltips for fixed position elements
* `_isEnabled` schema för course.json
* Documentation
* Other navigation buttons and plugins
* Check styling with experts
* Overlayed tooltips for larger regions where no space is available 
