### PR TITLE
Update: Remove tabindex from a11y.toggleEnabled (fixes #220)

### DIFF
--- a/js/a11y.js
+++ b/js/a11y.js
@@ -300,11 +300,10 @@ class A11y extends Backbone.Controller {
     }
     if (!isEnabled) {
       $elements.attr({
-        tabindex: '-1',
         'aria-disabled': 'true'
       }).addClass('is-disabled');
     } else {
-      $elements.removeAttr('aria-disabled tabindex').removeClass('is-disabled');
+      $elements.removeAttr('aria-disabled').removeClass('is-disabled');
     }
     return this;
   }


### PR DESCRIPTION
Fixes #220

### Update
* Removes tabindex from a11y.toggleEnabled

### Testing
1. Add a Hotgraphic component to a course.
2. Click on an item to open the Notify popup.
3. The disabled buttons should be focusable. Requires https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/241


