### PR TITLE
Fix: aria-level is set to "0" for headings (fixes #233)

### DIFF
--- a/js/a11y.js
+++ b/js/a11y.js
@@ -189,6 +189,8 @@ class A11y extends Backbone.Controller {
     }
     // get the global configuration from config.json
     const ariaLevels = Adapt.config.get('_accessibility')?._ariaLevels ?? defaultAriaLevels;
+    // Fix for authoring tool schema _ariaLevel = 0 default
+    if (override === 0) override = null;
     /**
      * Recursive function to calculate aria-level
      * @param {string} id Model id
@@ -197,8 +199,6 @@ class A11y extends Backbone.Controller {
      * @returns
      */
     function calculateLevel(id = null, level, offset = 0) {
-      // Fix for authoring tool schema _ariaLevel = 0 default
-      if (override === 0) override = null;
       const isNumber = !isNaN(level);
       const isTypeName = /[a-zA-z]/.test(level);
       if (!isTypeName && isNumber) {

--- a/js/a11y.js
+++ b/js/a11y.js
@@ -219,7 +219,7 @@ class A11y extends Backbone.Controller {
       const nextModelId = nextModel?.get('_id') ?? id;
       // check overrides, check title existence, adjust offset accordingly
       const hasNextTitle = Boolean(nextModel.get('displayTitle'));
-      const nextModelOverride = nextModel.get('_ariaLevel');
+      let nextModelOverride = nextModel.get('_ariaLevel');
       // Fix for authoring tool schema _ariaLevel = 0 default
       if (nextModelOverride === 0) nextModelOverride = null;
       const accumulatedOffset = offset + (hasNextTitle ? relativeDescriptor.offset : 0);

--- a/js/a11y.js
+++ b/js/a11y.js
@@ -197,6 +197,8 @@ class A11y extends Backbone.Controller {
      * @returns
      */
     function calculateLevel(id = null, level, offset = 0) {
+      // Fix for authoring tool schema _ariaLevel = 0 default
+      if (override === 0) override = null;
       const isNumber = !isNaN(level);
       const isTypeName = /[a-zA-z]/.test(level);
       if (!isTypeName && isNumber) {
@@ -218,12 +220,14 @@ class A11y extends Backbone.Controller {
       // check overrides, check title existence, adjust offset accordingly
       const hasNextTitle = Boolean(nextModel.get('displayTitle'));
       const nextModelOverride = nextModel.get('_ariaLevel');
+      // Fix for authoring tool schema _ariaLevel = 0 default
+      if (nextModelOverride === 0) nextModelOverride = null;
       const accumulatedOffset = offset + (hasNextTitle ? relativeDescriptor.offset : 0);
-      const resolvedLevel = nextModelOverride || nextLevel;
+      const resolvedLevel = nextModelOverride ?? nextLevel;
       // move towards the parents until an absolute value is found
       return calculateLevel(nextModelId, resolvedLevel, accumulatedOffset);
     }
-    return calculateLevel(id, override || level);
+    return calculateLevel(id, override ?? level);
   }
 
   /**

--- a/js/a11y.js
+++ b/js/a11y.js
@@ -219,11 +219,11 @@ class A11y extends Backbone.Controller {
       const hasNextTitle = Boolean(nextModel.get('displayTitle'));
       const nextModelOverride = nextModel.get('_ariaLevel');
       const accumulatedOffset = offset + (hasNextTitle ? relativeDescriptor.offset : 0);
-      const resolvedLevel = nextModelOverride ?? nextLevel;
+      const resolvedLevel = nextModelOverride || nextLevel;
       // move towards the parents until an absolute value is found
       return calculateLevel(nextModelId, resolvedLevel, accumulatedOffset);
     }
-    return calculateLevel(id, override ?? level);
+    return calculateLevel(id, override || level);
   }
 
   /**


### PR DESCRIPTION
Fixes #233

### Fix

* Change nullish coalescing operator to logical OR for ariaLevel check, so that 0 is not accepted as a level value.