### PR TITLE
Breaking: Use heading elements (Fixes #235)

### DIFF
--- a/templates/article.hbs
+++ b/templates/article.hbs
@@ -8,16 +8,8 @@
     <div class="article__header-inner">
 
       {{#if displayTitle}}
-      <div class="article__title">
-
-        {{#unless _disableAccessibilityState}}
-        <div class="js-heading"></div>
-        {{~/unless~}}
-
-        <div class="article__title-inner"{{#unless _disableAccessibilityState}} aria-hidden="true"{{/unless}}>
-          {{{compile displayTitle}}}
-        </div>
-
+      <div class="article__title js-heading-container">
+        <div class="js-heading article__title-inner"></div>
       </div>
       {{/if}}
 

--- a/templates/block.hbs
+++ b/templates/block.hbs
@@ -8,16 +8,8 @@
     <div class="block__header-inner">
 
       {{#if displayTitle}}
-      <div class="block__title">
-
-        {{#unless _disableAccessibilityState}}
-        <div class="js-heading"></div>
-        {{~/unless~}}
-
-        <div class="block__title-inner"{{#unless _disableAccessibilityState}} aria-hidden="true"{{/unless}}>
-          {{{compile displayTitle}}}
-        </div>
-
+      <div class="block__title js-heading-container">
+        <div class="js-heading block__title-inner"></div>
       </div>
       {{/if}}
 

--- a/templates/header.jsx
+++ b/templates/header.jsx
@@ -52,13 +52,8 @@ export default function Header(props) {
     <div id={`${_id}-header`} className={prefixClasses(classNamePrefixes, ['__header'])}>
       <div className={prefixClasses(classNamePrefixes, ['__header-inner'])}>
         {displayTitle &&
-        <div className={prefixClasses(classNamePrefixes, ['__title'])}>
-
-          {!_disableAccessibilityState &&
-          <div className="js-heading" ref={jsxHeading}></div>
-          }
-
-          <div className={prefixClasses(classNamePrefixes, ['__title-inner'])} aria-hidden={!_disableAccessibilityState} dangerouslySetInnerHTML={{ __html: compile(displayTitle, props) }} >
+        <div className={prefixClasses(classNamePrefixes, ['__title']) + " js-heading-container"}>
+          <div className={"js-heading " + prefixClasses(classNamePrefixes, ['__title-inner'])} ref={jsxHeading} dangerouslySetInnerHTML={{ __html: compile(displayTitle, props) }} >
           </div>
 
         </div>

--- a/templates/heading.hbs
+++ b/templates/heading.hbs
@@ -1,19 +1,16 @@
 {{import_globals}}
 
-<div id="{{_id}}-heading" class="js-heading-inner" role="heading" aria-level="{{a11y_aria_level _id _type _ariaLevel}}">
-
+<h{{a11y_aria_level _id _type _ariaLevel}} id="{{_id}}-heading" class="js-heading-inner">
   <span class="aria-label">
   {{#if _isA11yCompletionDescriptionEnabled}}
     {{#if _isOptional}}
-      {{{compile title}}}
       {{else if _isComplete}}
-      {{_globals._accessibility._ariaLabels.complete}}. {{{compile title}}}
+      {{_globals._accessibility._ariaLabels.complete}}.
       {{else}}
-      {{_globals._accessibility._ariaLabels.incomplete}}. {{{compile title}}}
+      {{_globals._accessibility._ariaLabels.incomplete}}.
     {{/if}}
     {{else}}
-    {{{compile title}}}
   {{/if}}
   </span>
-
-</div>
+  {{{compile displayTitle}}}
+</h{{a11y_aria_level _id _type _ariaLevel}}>

--- a/templates/partials/component.hbs
+++ b/templates/partials/component.hbs
@@ -6,16 +6,8 @@
   <div class="component__header-inner {{lowercase _component}}__header-inner">
 
     {{#if displayTitle}}
-    <div class="component__title {{lowercase _component}}__title">
-
-      {{#unless _disableAccessibilityState}}
-      <div class="js-heading"></div>
-      {{~/unless~}}
-
-      <div class="component__title-inner {{lowercase _component}}__title-inner"{{#unless _disableAccessibilityState}} aria-hidden="true"{{/unless}}>
-        {{~{compile displayTitle}~}}
-      </div>
-
+    <div class="component__title js-heading-container {{lowercase _component}}__title">
+      <div class="js-heading component__title-inner {{lowercase _component}}__title-inner"></div>
     </div>
     {{/if}}
 


### PR DESCRIPTION
Fixes #235

### Update

* Change old heading markup with heading elements.

### Breaking

* This will break other plugins that depend on the old heading structure (e.g. 
themes, menus, pageLevelProgress).


