### PR TITLE
Fix: Navigation button read order (fixes #238)

### DIFF
--- a/less/core/nav.less
+++ b/less/core/nav.less
@@ -17,6 +17,9 @@
     align-items: center;
   }
 
+  // Override floats on additional `nav__btn` elements part of plugins
+  // that haven't been updated to work with data-order yet.
+  // Can be removed in time.
   &__btn {
     float: none !important;
   }
@@ -43,16 +46,8 @@
     }
   }
 
-  &__back-btn {
-    .u-float-left;
-  }
-
   &__back-btn .icon {
     .icon-controls-small-left;
-  }
-
-  &__drawer-btn {
-    .u-float-right;
   }
 
   &__drawer-btn .icon {

--- a/less/core/nav.less
+++ b/less/core/nav.less
@@ -13,6 +13,16 @@
 
   &__inner {
     .l-container-responsive(@max-width);
+    display: flex;
+    align-items: center;
+  }
+
+  &__btn {
+    float: none !important;
+  }
+
+  &__spacer {
+    flex-grow: 1;
   }
 
   &__skip-btn {

--- a/schema/course.model.schema
+++ b/schema/course.model.schema
@@ -347,7 +347,60 @@
                 "_navOrder": {
                   "type": "number",
                   "title": "Navigation bar order",
-                  "default": 0
+                  "default": 100
+                }
+              }
+            },
+            "_navigation": {
+              "type": "object",
+              "title": "Navigation",
+              "default": {},
+              "properties": {
+                "_skipButton": {
+                  "type": "object",
+                  "title": "Skip navigation button",
+                  "default": {},
+                  "properties": {
+                    "_navOrder": {
+                      "type": "number",
+                      "title": "Navigation bar order",
+                      "default": -100
+                    }
+                  }
+                },
+                "_backButton": {
+                  "type": "object",
+                  "title": "Back button",
+                  "default": {},
+                  "properties": {
+                    "_navOrder": {
+                      "type": "number",
+                      "title": "Navigation bar order",
+                      "default": 0
+                    }
+                  }
+                },
+                "_spacers": {
+                  "type": "array",
+                  "required": false,
+                  "title": "Spacers",
+                  "default": [
+                    {
+                      "_navOrder": 0
+                    }
+                  ],
+                  "items": {
+                    "type": "object",
+                    "required": false,
+                    "title": "",
+                    "properties": {
+                      "_navOrder": {
+                        "type": "number",
+                        "title": "Navigation bar order",
+                        "default": 0
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -316,7 +316,57 @@
                     "_navOrder": {
                       "type": "number",
                       "title": "Navigation bar order",
-                      "default": 0
+                      "default": 100
+                    }
+                  }
+                },
+                "_navigation": {
+                  "type": "object",
+                  "title": "Navigation",
+                  "default": {},
+                  "properties": {
+                    "_skipButton": {
+                      "type": "object",
+                      "title": "Skip navigation button",
+                      "default": {},
+                      "properties": {
+                        "_navOrder": {
+                          "type": "number",
+                          "title": "Navigation bar order",
+                          "default": -100
+                        }
+                      }
+                    },
+                    "_backButton": {
+                      "type": "object",
+                      "title": "Back button",
+                      "default": {},
+                      "properties": {
+                        "_navOrder": {
+                          "type": "number",
+                          "title": "Navigation bar order",
+                          "default": 0
+                        }
+                      }
+                    },
+                    "_spacers": {
+                      "type": "array",
+                      "title": "Items",
+                      "default": [
+                        {
+                          "_navOrder": 0
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "_navOrder": {
+                            "type": "number",
+                            "title": "Navigation bar order",
+                            "default": 0
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/templates/nav.hbs
+++ b/templates/nav.hbs
@@ -5,14 +5,18 @@
 <div class="nav__inner u-clearfix">
 
   {{#if _accessibility._isSkipNavigationEnabled}}
-  <button class="btn-text nav__btn nav__skip-btn" data-event="skipNavigation" aria-label="{{_globals._accessibility._ariaLabels.skipNavigation}}">
+  <button class="btn-text nav__btn nav__skip-btn" data-event="skipNavigation" aria-label="{{_globals._accessibility._ariaLabels.skipNavigation}}" data-order="{{_globals._extensions._navigation._skipButton._navOrder}}">
     {{{_globals._accessibility.skipNavigationText}}}
   </button>
   {{/if}}
 
-  <button class="btn-icon nav__btn nav__back-btn js-nav-back-btn u-display-none" data-event="backButton" aria-label="{{_globals._accessibility._ariaLabels.previous}}" role="link">
+  <button class="btn-icon nav__btn nav__back-btn js-nav-back-btn u-display-none" data-event="backButton" aria-label="{{_globals._accessibility._ariaLabels.previous}}" role="link" data-order="{{_globals._extensions._navigation._backButton._navOrder}}">
     <span class="icon"></span>
   </button>
+  
+  {{#each _globals._extensions._navigation._spacers}}
+    <div class="nav__spacer" aria-hidden="true" data-order="{{_navOrder}}"></div>
+  {{/each}}
 
   <button class="btn-icon nav__btn nav__drawer-btn js-nav-drawer-btn" data-event="toggleDrawer" aria-expanded="false" aria-label="{{_globals._accessibility._ariaLabels.navigationDrawer}}" data-order="{{_globals._extensions._drawer._navOrder}}">
     <span class="icon"></span>

--- a/templates/nav.hbs
+++ b/templates/nav.hbs
@@ -2,7 +2,7 @@
 {{import_globals}}
 
 {{! All links in the nav bar should have an attribute of data-event, navigationView uses this to fire a global event}}
-<div class="nav__inner u-clearfix">
+<div class="nav__inner">
 
   {{#if _accessibility._isSkipNavigationEnabled}}
   <button class="btn-text nav__btn nav__skip-btn" data-event="skipNavigation" aria-label="{{_globals._accessibility._ariaLabels.skipNavigation}}" data-order="{{_globals._extensions._navigation._skipButton._navOrder}}">
@@ -13,7 +13,7 @@
   <button class="btn-icon nav__btn nav__back-btn js-nav-back-btn u-display-none" data-event="backButton" aria-label="{{_globals._accessibility._ariaLabels.previous}}" role="link" data-order="{{_globals._extensions._navigation._backButton._navOrder}}">
     <span class="icon"></span>
   </button>
-  
+
   {{#each _globals._extensions._navigation._spacers}}
     <div class="nav__spacer" aria-hidden="true" data-order="{{_navOrder}}"></div>
   {{/each}}


### PR DESCRIPTION
fixes #238
requires https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/pull/151
requires https://github.com/adaptlearning/adapt_framework/pull/3332

The dom order and visual order will be aligned, such that the screen reader read order is correct.

### Fix
* Moved from `float` styling to `flex`
* Added spacers
* Added default schema order for buttons and spacers
* Reorder happens when any child is changed
