### PR TITLE
Fix: Made headings clickable

### DIFF
--- a/js/views/headingView.js
+++ b/js/views/headingView.js
@@ -12,6 +12,8 @@ class HeadingView extends Backbone.View {
     const template = Handlebars.templates[this.constructor.template];
     const data = this.model.toJSON();
     const customHeadingType = this.$el.attr('data-a11y-heading-type');
+    const isBackwardCompatible = [...this.$el[0].classList].every(name => !name.includes('-inner'));
+    data._isBackwardCompatible = isBackwardCompatible;
     if (customHeadingType) data._type = customHeadingType;
     if (data._type === 'course') data._type = 'menu';
     this.$el.html(template(data));

--- a/templates/article.hbs
+++ b/templates/article.hbs
@@ -8,7 +8,7 @@
     <div class="article__header-inner">
 
       {{#if displayTitle}}
-      <div class="article__title js-heading-container">
+      <div class="article__title">
         <div class="js-heading article__title-inner"></div>
       </div>
       {{/if}}

--- a/templates/article.hbs
+++ b/templates/article.hbs
@@ -9,7 +9,7 @@
 
       {{#if displayTitle}}
       <div class="article__title">
-        <div class="js-heading article__title-inner"></div>
+        <div class="article__title-inner js-heading"></div>
       </div>
       {{/if}}
 

--- a/templates/article.hbs
+++ b/templates/article.hbs
@@ -8,16 +8,8 @@
     <div class="article__header-inner">
 
       {{#if displayTitle}}
-      <div class="article__title">
-
-        {{#unless _disableAccessibilityState}}
-        <div class="js-heading"></div>
-        {{~/unless~}}
-
-        <div class="article__title-inner"{{#unless _disableAccessibilityState}} aria-hidden="true"{{/unless}}>
-          {{{compile displayTitle}}}
-        </div>
-
+      <div class="article__title js-heading-container">
+        <div class="js-heading article__title-inner"></div>
       </div>
       {{/if}}
 

--- a/templates/block.hbs
+++ b/templates/block.hbs
@@ -9,7 +9,7 @@
 
       {{#if displayTitle}}
       <div class="block__title">
-        <div class="js-heading block__title-inner"></div>
+        <div class="block__title-inner js-heading"></div>
       </div>
       {{/if}}
 

--- a/templates/block.hbs
+++ b/templates/block.hbs
@@ -8,16 +8,8 @@
     <div class="block__header-inner">
 
       {{#if displayTitle}}
-      <div class="block__title">
-
-        {{#unless _disableAccessibilityState}}
-        <div class="js-heading"></div>
-        {{~/unless~}}
-
-        <div class="block__title-inner"{{#unless _disableAccessibilityState}} aria-hidden="true"{{/unless}}>
-          {{{compile displayTitle}}}
-        </div>
-
+      <div class="block__title js-heading-container">
+        <div class="js-heading block__title-inner"></div>
       </div>
       {{/if}}
 

--- a/templates/block.hbs
+++ b/templates/block.hbs
@@ -8,7 +8,7 @@
     <div class="block__header-inner">
 
       {{#if displayTitle}}
-      <div class="block__title js-heading-container">
+      <div class="block__title">
         <div class="js-heading block__title-inner"></div>
       </div>
       {{/if}}

--- a/templates/header.jsx
+++ b/templates/header.jsx
@@ -52,9 +52,7 @@ export default function Header(props) {
       <div className={prefixClasses(classNamePrefixes, ['__header-inner'])}>
         {displayTitle &&
         <div className={prefixClasses(classNamePrefixes, ['__title'])}>
-          <div className={'js-heading ' + prefixClasses(classNamePrefixes, ['__title-inner'])} ref={jsxHeading} dangerouslySetInnerHTML={{ __html: compile(displayTitle, props) }} >
-          </div>
-
+          <div className={'js-heading ' + prefixClasses(classNamePrefixes, ['__title-inner'])} ref={jsxHeading}></div>
         </div>
         }
 

--- a/templates/header.jsx
+++ b/templates/header.jsx
@@ -52,13 +52,8 @@ export default function Header(props) {
     <div id={`${_id}-header`} className={prefixClasses(classNamePrefixes, ['__header'])}>
       <div className={prefixClasses(classNamePrefixes, ['__header-inner'])}>
         {displayTitle &&
-        <div className={prefixClasses(classNamePrefixes, ['__title'])}>
-
-          {!_disableAccessibilityState &&
-          <div className="js-heading" ref={jsxHeading}></div>
-          }
-
-          <div className={prefixClasses(classNamePrefixes, ['__title-inner'])} aria-hidden={!_disableAccessibilityState} dangerouslySetInnerHTML={{ __html: compile(displayTitle, props) }} >
+        <div className={prefixClasses(classNamePrefixes, ['__title']) + " js-heading-container"}>
+          <div className={"js-heading " + prefixClasses(classNamePrefixes, ['__title-inner'])} ref={jsxHeading} dangerouslySetInnerHTML={{ __html: compile(displayTitle, props) }} >
           </div>
 
         </div>

--- a/templates/header.jsx
+++ b/templates/header.jsx
@@ -26,7 +26,6 @@ export default function Header(props) {
     mobileInstruction,
     _type,
     _component,
-    _disableAccessibilityState,
     _isA11yComponentDescriptionEnabled,
     classNamePrefixes = [
       _type && _type.toLowerCase(),
@@ -52,8 +51,8 @@ export default function Header(props) {
     <div id={`${_id}-header`} className={prefixClasses(classNamePrefixes, ['__header'])}>
       <div className={prefixClasses(classNamePrefixes, ['__header-inner'])}>
         {displayTitle &&
-        <div className={prefixClasses(classNamePrefixes, ['__title']) + " js-heading-container"}>
-          <div className={"js-heading " + prefixClasses(classNamePrefixes, ['__title-inner'])} ref={jsxHeading} dangerouslySetInnerHTML={{ __html: compile(displayTitle, props) }} >
+        <div className={prefixClasses(classNamePrefixes, ['__title'])}>
+          <div className={'js-heading ' + prefixClasses(classNamePrefixes, ['__title-inner'])} ref={jsxHeading} dangerouslySetInnerHTML={{ __html: compile(displayTitle, props) }} >
           </div>
 
         </div>

--- a/templates/header.jsx
+++ b/templates/header.jsx
@@ -52,7 +52,7 @@ export default function Header(props) {
       <div className={prefixClasses(classNamePrefixes, ['__header-inner'])}>
         {displayTitle &&
         <div className={prefixClasses(classNamePrefixes, ['__title'])}>
-          <div className={'js-heading ' + prefixClasses(classNamePrefixes, ['__title-inner'])} ref={jsxHeading}></div>
+          <div className={prefixClasses(classNamePrefixes, ['__title-inner']) + ' js-heading'} ref={jsxHeading}></div>
         </div>
         }
 

--- a/templates/heading.hbs
+++ b/templates/heading.hbs
@@ -1,6 +1,6 @@
 {{import_globals}}
 
-<div id="{{_id}}-heading" role="heading" aria-level="{{a11y_aria_level _id _type _ariaLevel}}">
+<div id="{{_id}}-heading" role="heading" class="js-heading-inner" aria-level="{{a11y_aria_level _id _type _ariaLevel}}">
   <span class="aria-label">
   {{#if _isA11yCompletionDescriptionEnabled}}
     {{#if _isOptional}}

--- a/templates/heading.hbs
+++ b/templates/heading.hbs
@@ -1,6 +1,6 @@
 {{import_globals}}
 
-<div id="{{_id}}-heading" role="heading" class="js-heading-inner" aria-level="{{a11y_aria_level _id _type _ariaLevel}}">
+<div id="{{_id}}-heading" class="js-heading-inner" role="heading" aria-level="{{a11y_aria_level _id _type _ariaLevel}}">
   <span class="aria-label">
   {{#if _isA11yCompletionDescriptionEnabled}}
     {{#if _isOptional}}

--- a/templates/heading.hbs
+++ b/templates/heading.hbs
@@ -1,19 +1,16 @@
 {{import_globals}}
 
-<div id="{{_id}}-heading" class="js-heading-inner" role="heading" aria-level="{{a11y_aria_level _id _type _ariaLevel}}">
-
+<h{{a11y_aria_level _id _type _ariaLevel}} id="{{_id}}-heading" class="js-heading-inner">
   <span class="aria-label">
   {{#if _isA11yCompletionDescriptionEnabled}}
     {{#if _isOptional}}
-      {{{compile title}}}
       {{else if _isComplete}}
-      {{_globals._accessibility._ariaLabels.complete}}. {{{compile title}}}
+      {{_globals._accessibility._ariaLabels.complete}}.
       {{else}}
-      {{_globals._accessibility._ariaLabels.incomplete}}. {{{compile title}}}
+      {{_globals._accessibility._ariaLabels.incomplete}}.
     {{/if}}
     {{else}}
-    {{{compile title}}}
   {{/if}}
   </span>
-
-</div>
+  {{{compile displayTitle}}}
+</h{{a11y_aria_level _id _type _ariaLevel}}>

--- a/templates/heading.hbs
+++ b/templates/heading.hbs
@@ -1,16 +1,21 @@
 {{import_globals}}
 
-<h{{a11y_aria_level _id _type _ariaLevel}} id="{{_id}}-heading" class="js-heading-inner">
+<div id="{{_id}}-heading" role="heading" aria-level="{{a11y_aria_level _id _type _ariaLevel}}">
   <span class="aria-label">
   {{#if _isA11yCompletionDescriptionEnabled}}
     {{#if _isOptional}}
       {{else if _isComplete}}
-      {{_globals._accessibility._ariaLabels.complete}}.
+      {{_globals._accessibility._ariaLabels.complete}}.&nbsp;
       {{else}}
-      {{_globals._accessibility._ariaLabels.incomplete}}.
+      {{_globals._accessibility._ariaLabels.incomplete}}.&nbsp;
     {{/if}}
     {{else}}
   {{/if}}
-  </span>
+  {{#if _isBackwardCompatible}}
   {{{compile displayTitle}}}
-</h{{a11y_aria_level _id _type _ariaLevel}}>
+  {{/if}}
+  </span>
+  {{#unless _isBackwardCompatible}}
+  {{{compile displayTitle}}}
+  {{/unless}}
+</div>

--- a/templates/page.hbs
+++ b/templates/page.hbs
@@ -8,16 +8,8 @@
     <div class="page__header-inner">
 
       {{#if displayTitle}}
-      <div class="page__title">
-
-        {{#unless _disableAccessibilityState}}
-        <div class="js-heading"></div>
-        {{~/unless~}}
-
-        <div class="page__title-inner" {{#unless _disableAccessibilityState}}aria-hidden="true"{{/unless}}>
-          {{{compile displayTitle}}}
-        </div>
-
+      <div class="page__title js-heading-container">
+        <div class="js-heading page__title-inner"></div>
       </div>
       {{/if}}
 

--- a/templates/page.hbs
+++ b/templates/page.hbs
@@ -9,7 +9,7 @@
 
       {{#if displayTitle}}
       <div class="page__title">
-        <div class="js-heading page__title-inner"></div>
+        <div class="page__title-inner js-heading"></div>
       </div>
       {{/if}}
 

--- a/templates/page.hbs
+++ b/templates/page.hbs
@@ -8,7 +8,7 @@
     <div class="page__header-inner">
 
       {{#if displayTitle}}
-      <div class="page__title js-heading-container">
+      <div class="page__title">
         <div class="js-heading page__title-inner"></div>
       </div>
       {{/if}}

--- a/templates/partials/component.hbs
+++ b/templates/partials/component.hbs
@@ -6,7 +6,7 @@
   <div class="component__header-inner {{lowercase _component}}__header-inner">
 
     {{#if displayTitle}}
-    <div class="component__title js-heading-container {{lowercase _component}}__title">
+    <div class="component__title {{lowercase _component}}__title">
       <div class="js-heading component__title-inner {{lowercase _component}}__title-inner"></div>
     </div>
     {{/if}}

--- a/templates/partials/component.hbs
+++ b/templates/partials/component.hbs
@@ -6,16 +6,8 @@
   <div class="component__header-inner {{lowercase _component}}__header-inner">
 
     {{#if displayTitle}}
-    <div class="component__title {{lowercase _component}}__title">
-
-      {{#unless _disableAccessibilityState}}
-      <div class="js-heading"></div>
-      {{~/unless~}}
-
-      <div class="component__title-inner {{lowercase _component}}__title-inner"{{#unless _disableAccessibilityState}} aria-hidden="true"{{/unless}}>
-        {{~{compile displayTitle}~}}
-      </div>
-
+    <div class="component__title js-heading-container {{lowercase _component}}__title">
+      <div class="js-heading component__title-inner {{lowercase _component}}__title-inner"></div>
     </div>
     {{/if}}
 

--- a/templates/partials/component.hbs
+++ b/templates/partials/component.hbs
@@ -7,7 +7,7 @@
 
     {{#if displayTitle}}
     <div class="component__title {{lowercase _component}}__title">
-      <div class="js-heading component__title-inner {{lowercase _component}}__title-inner"></div>
+      <div class="component__title-inner {{lowercase _component}}__title-inner js-heading"></div>
     </div>
     {{/if}}
 


### PR DESCRIPTION
fixes #235 

Instead of using semantic heading levels, as this requires a lot of styling fixes in vanilla, I've focused more on making the headings clickable and unified, rather than having a separate heading for accessibility.

### Fix
* Unify accessible and display headings

Requires 
https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/pull/152
https://github.com/adaptlearning/adapt-contrib-boxMenu/pull/127