### PR TITLE
Update: Ability to log call stack for debugging

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/js/logging.js
+++ b/js/logging.js
@@ -8,7 +8,8 @@ class Logging extends Backbone.Controller {
       _isEnabled: true,
       _level: LOG_LEVEL.INFO.asLowerCase, // Default log level
       _console: true, // Log to console
-      _warnFirstOnly: true // Show only first of identical removed and deprecated warnings
+      _warnFirstOnly: true, // Show only first of identical removed and deprecated warnings
+      _showCallStack: false // Display the full call stack (console.trace)
     };
     this._warned = {};
     this.listenToOnce(Adapt, 'configModel:dataLoaded', this.onLoadConfigData);
@@ -117,6 +118,11 @@ class Logging extends Backbone.Controller {
     } else {
       console.log(...log);
     }
+
+    const shouldShowCallStack = (this._config._showCallStack);
+    if (!shouldShowCallStack) return;
+
+    console.trace();
   }
 
   _hasWarned(args) {

--- a/schema/config.model.schema
+++ b/schema/config.model.schema
@@ -381,6 +381,13 @@
           "inputType": "Checkbox",
           "validators": [],
           "title": "Show only first deprecated and removed warnings?"
+        },
+        "_showCallStack": {
+          "type": "boolean",
+          "default": false,
+          "inputType": "Checkbox",
+          "validators": [],
+          "title": "Display the full call stack (console.trace)?"
         }
       }
     },

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -349,6 +349,11 @@
           "type": "boolean",
           "title": "Suppress subsequent deprecation warnings",
           "default": true
+        },
+        "_showCallStack": {
+          "type": "boolean",
+          "title": "Output console.trace()",
+          "default": false
         }
       }
     },


### PR DESCRIPTION
Added new config value to optionally turn on console.trace to display call stack for debugging

[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes: #249 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Update
* Configurable '_showCallStack' logging setting (default false). Turning on will output console.trace after usual console output

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Create a course that uses plugin(s) which have not yet been moved over to imported singletons (custom plugin or older version of one may be required)
2. Edit config and set _showCallStack to true
3. Preview the course and inspect
4. Call stack should be output in console