### PR TITLE
Fix: Core cannot find parent on language change triggered by trickle

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -235,7 +235,7 @@ class Data extends AdaptCollection {
   findById(id) {
     const model = this._byAdaptID[id];
     if (!model) {
-      console.warn(`data.findById() unable to find id: ${id}`);
+      logging.warn(`data.findById() unable to find id: ${id}`);
       return;
     }
     return model;
@@ -259,7 +259,7 @@ class Data extends AdaptCollection {
     });
 
     if (!currentLocationModel) {
-      return console.warn(`data.findViewByModelId() unable to find view for model id: ${id}`);
+      return logging.warn(`data.findViewByModelId() unable to find view for model id: ${id}`);
     }
 
     const foundView = idPathToView.reduce((view, currentId) => {
@@ -280,7 +280,7 @@ class Data extends AdaptCollection {
     const [ trackingId, indexInTrackingIdDescendants ] = trackingPosition;
     const trackingIdModel = this.find(model => model.get('_trackingId') === trackingId);
     if (!trackingIdModel) {
-      console.warn(`data.findByTrackingPosition() unable to find trackingPosition: ${trackingPosition}`);
+      logging.warn(`data.findByTrackingPosition() unable to find trackingPosition: ${trackingPosition}`);
       return;
     }
     if (indexInTrackingIdDescendants >= 0) {

--- a/js/models/adaptModel.js
+++ b/js/models/adaptModel.js
@@ -661,7 +661,13 @@ export default class AdaptModel extends LockingModel {
     const parentId = this.get('_parentId');
     if (!parentId) return;
     // Look up parent by id from data
-    this.setParent(data.findById(parentId));
+    const parent = data.findById(parentId);
+    if (!parent) {
+      logging.warn('adaptModel.getParent(): parent is empty');
+      return;
+    }
+
+    this.setParent(parent);
     return this._parentModel;
   }
 
@@ -762,7 +768,7 @@ export default class AdaptModel extends LockingModel {
         this.setCustomLocking();
         break;
       default:
-        console.warn(`AdaptModel.checkLocking: unknown _lockType '${lockType}' found on ${this.get('_id')}`);
+        logging.warn(`AdaptModel.checkLocking: unknown _lockType '${lockType}' found on ${this.get('_id')}`);
     }
   }
 
@@ -815,7 +821,7 @@ export default class AdaptModel extends LockingModel {
             )
           );
       } catch (e) {
-        console.warn(`AdaptModel.shouldLock: unknown _lockedBy ID '${id}' found on ${child.get('_id')}`);
+        logging.warn(`AdaptModel.shouldLock: unknown _lockedBy ID '${id}' found on ${child.get('_id')}`);
         return false;
       }
     });


### PR DESCRIPTION
Ensures no fallover when parent is empty

[//]: # (Link the PR to the original issue)
Fixes [#248](https://github.com/adaptlearning/adapt-contrib-core/issues/248)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* logging.warn of empty parent object on fetch
* Updated console.warns to go through the Logging class in a few places

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Create a basic 2 page course with blank components on each
2. Add Trickle and LanguagePicker extension
3. Add second language
4. Start the course and enter a page
5. Change language

###Broken behaviour
Language switch fails
Screen JS becomes broken (incomplete rendering etc)

###New behaviour
Console warning indicates no parent available
Screen renders menu view for new language
