### PR TITLE
Fix: Allow plugins to pause rendering (fixes #257)

### DIFF
--- a/js/views/adaptView.js
+++ b/js/views/adaptView.js
@@ -18,6 +18,7 @@ class AdaptView extends Backbone.View {
   }
 
   initialize() {
+    this._jsxIgnoreChanges = 0;
     this.listenTo(this.model, {
       'change:_isVisible': this.toggleVisibility,
       'change:_isHidden': this.toggleHidden,
@@ -84,6 +85,7 @@ class AdaptView extends Backbone.View {
    * @param {string} eventName=null Backbone change event name
    */
   changed(eventName = null) {
+    if (this._jsxIgnoreChanges !== 0) return;
     if (!this.isJSX) {
       throw new Error('Cannot call changed on a non-react view');
     }
@@ -102,6 +104,17 @@ class AdaptView extends Backbone.View {
     const Template = templates[this.constructor.template.replace('.jsx', '')];
     this.updateViewProperties();
     ReactDOM.render(<Template {...props} />, this.el);
+  }
+
+  stopRendering() {
+    this._jsxIgnoreChanges++;
+  }
+
+  startRendering() {
+    this._jsxIgnoreChanges--;
+    if (this._jsxIgnoreChanges < 0) {
+      this._jsxIgnoreChanges = 0;
+    }
   }
 
   updateViewProperties() {

--- a/js/views/questionView.js
+++ b/js/views/questionView.js
@@ -226,11 +226,12 @@ class QuestionView extends ComponentView {
     // Update buttons happens before showFeedback to preserve tabindexes and after setupFeedback to allow buttons to use feedback attribute
     this._runModelCompatibleFunction('updateButtons');
 
-    this.model.onSubmitted();
-    this.onSubmitted();
-
     this.startRendering();
     this.changed();
+    
+    this.model.onSubmitted();
+    this.onSubmitted();
+    Adapt.trigger('questionView:submitted', this);
   }
 
   showInstructionError() {

--- a/js/views/questionView.js
+++ b/js/views/questionView.js
@@ -177,6 +177,8 @@ class QuestionView extends ComponentView {
       return;
     }
 
+    this.stopRendering();
+
     // Used to update the amount of attempts the question has
     this._runModelCompatibleFunction('updateAttempts');
 
@@ -226,7 +228,9 @@ class QuestionView extends ComponentView {
 
     this.model.onSubmitted();
     this.onSubmitted();
-    Adapt.trigger('questionView:submitted', this);
+
+    this.startRendering();
+    this.changed();
   }
 
   showInstructionError() {


### PR DESCRIPTION
fixes #257 

### Fix
* Allow plugins to pause rendering
* Stop and start rendering in `onSubmitClicked` handler to reduce cpu usage

