### PR TITLE
Fix: Changed component right rtl margin-left value (fixes #263)

### DIFF
--- a/less/core/component.less
+++ b/less/core/component.less
@@ -22,7 +22,7 @@
       width: 50%;
 
       .dir-rtl & {
-        margin-left: inherit;
+        margin-left: 0;
         margin-right: auto;
       }
     }


### PR DESCRIPTION
Fixes: #263 

### Fix
* Changed component right rtl margin-left value from `inherit` to `0` to resolve visual offset error
