### PR TITLE
Fix: helper() function in reactHelpers (fixes #270)

### DIFF
--- a/js/reactHelpers.js
+++ b/js/reactHelpers.js
@@ -88,7 +88,7 @@ export function partial(name, ...args) {
  * @param {...any} args Helper arguments
  */
 export function helper(name, ...args) {
-  const output = Handlebars.helpers[name].call(args[0]);
+  const output = Handlebars.helpers[name].call(this, args[0]);
   return (output && output.string) || output;
 };
 


### PR DESCRIPTION
Fixes #270 

### Fix
* Passes in the 'this' keyword to the call() function in helper().

### Testing
Refer to #270 


