### PR TITLE
Fix: `_isOptional` completion

### DIFF
--- a/js/models/adaptModel.js
+++ b/js/models/adaptModel.js
@@ -312,19 +312,20 @@ export default class AdaptModel extends LockingModel {
   }
 
   /**
-   * Function for checking whether the supplied completion attribute should be set to true or false.
-   * It iterates over our immediate children, checking the same completion attribute on any mandatory child
-   * to see if enough/all of them them have been completed. If enough/all have, we set our attribute to true;
-   * if not, we set it to false.
+   * Checks whether the supplied completion attribute should be set to true or false.
+   * Iterates over immediate children, checking if enough/all mandatory models have been completed.
+   * If all children are optional, they must all be completed - https://github.com/adaptlearning/adapt-contrib-core/issues/279
    * @param {string} [completionAttribute] Either '_isComplete' or '_isInteractionComplete'. Defaults to '_isComplete' if not supplied.
    */
-
   checkCompletionStatusFor(completionAttribute = '_isComplete') {
     let completed = false;
     const children = this.getAvailableChildModels();
     const requireCompletionOf = this.get('_requireCompletionOf');
+    const isEveryChildOptional = children.every(child => child.get('_isOptional'));
 
-    if (requireCompletionOf === -1) { // a value of -1 indicates that ALL mandatory children must be completed
+    if (isEveryChildOptional) {
+      completed = children.every(child => child.get(completionAttribute));
+    } else if (requireCompletionOf === -1) { // a value of -1 indicates that ALL mandatory children must be completed
       completed = children.every(child => {
         return child.get(completionAttribute) || child.get('_isOptional');
       });
@@ -335,7 +336,6 @@ export default class AdaptModel extends LockingModel {
     }
 
     this.set(completionAttribute, completed);
-
     Adapt.checkedCompletion();
   }
 


### PR DESCRIPTION
Fixes #279.

### Fix
* Account for every child being `_isOptional` when checking/setting completion.

