### PR TITLE
Fix: Enable Show Feedback button when feedback content only has a title (fixes #265)

### DIFF
--- a/js/views/buttonsView.js
+++ b/js/views/buttonsView.js
@@ -198,7 +198,7 @@ export default class ButtonsView extends Backbone.View {
     this.checkResetSubmittedState();
     this.checkFeedbackState();
     this.onButtonStateChanged(null, this.model.get('_buttonState'));
-    this.disableFeedbackButton();
+    this.onFeedbackMessageChanged(null, this.model.get('_isSubmitted'));
   }
 
 }

--- a/js/views/buttonsView.js
+++ b/js/views/buttonsView.js
@@ -86,9 +86,8 @@ export default class ButtonsView extends Backbone.View {
   onFeedbackMessageChanged(model, changedAttribute) {
     if (!this.model.get('_canShowFeedback')) return;
 
-    if (changedAttribute) {
-      this.enableFeedbackButton();
-    }
+    if (!changedAttribute) return;
+    this.enableFeedbackButton();
   }
 
   enableFeedbackButton() {

--- a/js/views/buttonsView.js
+++ b/js/views/buttonsView.js
@@ -1,7 +1,7 @@
 import Adapt from 'core/js/adapt';
 import a11y from 'core/js/a11y';
 import BUTTON_STATE from 'core/js/enums/buttonStateEnum';
-import logging from 'core/js/logging'
+import logging from 'core/js/logging';
 
 // convert BUTTON_STATE to property name
 const textPropertyName = {
@@ -84,13 +84,14 @@ export default class ButtonsView extends Backbone.View {
   }
 
   onFeedbackMessageChanged(model, changedAttribute) {
-    if (!this.model.get('_canShowFeedback')) return;
-
     if (!changedAttribute) return;
+
     this.enableFeedbackButton();
   }
 
   enableFeedbackButton() {
+    if (!this.model.get('_canShowFeedback')) return;
+
     a11y.toggleEnabled(this.$('.js-btn-feedback'), true);
   }
 

--- a/js/views/buttonsView.js
+++ b/js/views/buttonsView.js
@@ -22,6 +22,7 @@ export default class ButtonsView extends Backbone.View {
     this.listenTo(this.model, {
       'change:_buttonState': this.onButtonStateChanged,
       'change:feedbackMessage': this.onFeedbackMessageChanged,
+      'change:feedbackTitle': this.onFeedbackMessageChanged,
       'change:_attemptsLeft': this.onAttemptsChanged,
       'change:_canSubmit': this.onCanSubmitChange
     });
@@ -59,7 +60,7 @@ export default class ButtonsView extends Backbone.View {
     this.$('.js-btn-marking, .js-btn-marking-label').removeClass('is-incorrect is-correct').addClass('u-display-none');
     this.$el.removeClass('is-submitted');
     this.model.set('feedbackMessage', undefined);
-    a11y.toggleEnabled(this.$('.js-btn-feedback'), false);
+    this.disableFeedbackButton();
   }
 
   onActionClicked() {
@@ -83,12 +84,18 @@ export default class ButtonsView extends Backbone.View {
   }
 
   onFeedbackMessageChanged(model, changedAttribute) {
-    if (changedAttribute && this.model.get('_canShowFeedback')) {
-      // enable feedback button
-      a11y.toggleEnabled(this.$('.js-btn-feedback'), true);
-      return;
+    if (!this.model.get('_canShowFeedback')) return;
+
+    if (changedAttribute) {
+      this.enableFeedbackButton();
     }
-    // disable feedback button
+  }
+
+  enableFeedbackButton() {
+    a11y.toggleEnabled(this.$('.js-btn-feedback'), true);
+  }
+
+  disableFeedbackButton() {
     a11y.toggleEnabled(this.$('.js-btn-feedback'), false);
   }
 
@@ -191,7 +198,7 @@ export default class ButtonsView extends Backbone.View {
     this.checkResetSubmittedState();
     this.checkFeedbackState();
     this.onButtonStateChanged(null, this.model.get('_buttonState'));
-    this.onFeedbackMessageChanged(null, this.model.get('feedbackMessage'));
+    this.disableFeedbackButton();
   }
 
 }


### PR DESCRIPTION
Fixes #265

### Fix
* Add another event listener for when `feedbackTitle` changes. This allows the feedback button to be enabled when the feedback content only has a title and no body text.
* `onFeedbackMessageChanged()` is now only concerned with _enabling_ (not disabling) the Feedback button.
* In `refresh()`, use the new method `disableFeedbackButton()` instead of `onFeedbackMessageChanged()`.

### Testing
1. Include the following feedback in a question:

```
"_feedback": {
  "altTitle": "",
  "title": "Feedback global title",
  "_classes": "",
  "_correct": {
    "altTitle": "",
    "title": "Correct feedback title",
    "body": ""
  },
  "_incorrectNotFinal": {
    "altTitle": "",
    "title": "",
    "body": "Incorrect feedback body, not final"
  },
  "_incorrectFinal": {
    "altTitle": "",
    "title": "",
    "body": "Incorrect feedback body, final"
  }
},
```
2. Set `_canShowFeedback` to `true`
3. Ensure the Show Feedback button can be clicked when either answering correctly (title text only) or incorrectly (body text only).