### PR TITLE
Fix: Remove schema duplication (fixes #297)

### DIFF
--- a/schema/article.schema.json
+++ b/schema/article.schema.json
@@ -4,20 +4,10 @@
   "type": "object",
   "$merge": {
     "source": {
-      "$ref": "content"
+      "$ref": "contentcontainer"
     },
     "with": {
-      "properties": {
-        "_requireCompletionOf": {
-          "type": "number",
-          "title": "Number of blocks required for completion",
-          "description": "The number of blocks within this article the learner must complete in order for this article to be set as completed. A value of -1 requires all of them to be completed",
-          "default": -1,
-          "_adapt": {
-            "isSetting": true
-          }
-        }
-      }
+      "properties": {}
     }
   }
 }

--- a/schema/block.schema.json
+++ b/schema/block.schema.json
@@ -4,7 +4,7 @@
   "type": "object",
   "$merge": {
     "source": {
-      "$ref": "content"
+      "$ref": "contentcontainer"
     },
     "with": {
       "properties": {
@@ -19,15 +19,6 @@
           "default": [],
           "_adapt": {
             "editorOnly": true
-          }
-        },
-        "_requireCompletionOf": {
-          "type": "number",
-          "title": "Number of components required for completion",
-          "description": "The number of components within this block the learner must complete in order for this block to be set as completed. A value of -1 requires all of them to be completed",
-          "default": -1,
-          "_adapt": {
-            "isSetting": true
           }
         }
       }

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -15,6 +15,19 @@
           "type": "string",
           "title": "Component"
         },
+        "_supportedLayout": {
+          "type": "string",
+          "title": "Supported layout",
+          "default": "both",
+          "enum": [
+            "full-width",
+            "half-width",
+            "both"
+          ],
+          "_adapt": {
+            "editorOnly": true
+          }
+        },
         "_layout": {
           "type": "string",
           "title": "Layout",
@@ -44,10 +57,11 @@
             "isSetting": true
           }
         },
-        "properties": {
-          "type": "object",
-          "title": "Properties",
-          "default": {}
+        "tags": {
+          "type": "string",
+          "_backboneForms": {
+            "showInUi": false
+          }
         }
       }
     }

--- a/schema/contentcontainer.schema.json
+++ b/schema/contentcontainer.schema.json
@@ -1,0 +1,23 @@
+{
+  "$anchor": "contentcontainer",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "$merge": {
+    "source": {
+      "$ref": "content"
+    },
+    "with": {
+      "properties": {
+        "_requireCompletionOf": {
+          "type": "number",
+          "title": "Number of child content objects required for completion",
+          "description": "The number of child content objects the learner must complete in order for this item to be set as completed. A value of -1 requires all of them to be completed",
+          "default": -1,
+          "_adapt": {
+            "isSetting": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -4,7 +4,7 @@
   "type": "object",
   "$merge": {
     "source": {
-      "$ref": "content"
+      "$ref": "contentcontainer"
     },
     "with": {
       "properties": {
@@ -95,15 +95,6 @@
             "unlockFirst"
           ],
           "_backboneForms": "Select"
-        },
-        "_requireCompletionOf": {
-          "type": "number",
-          "title": "Number of articles required for completion",
-          "description": "The number of articles within this page the learner must complete in order for this page to be set as completed. A value of -1 requires all of them to be completed",
-          "default": -1,
-          "_adapt": {
-            "isSetting": true
-          }
         },
         "menuSettings": {
           "type": "object",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -4,7 +4,7 @@
   "type": "object",
   "$merge": {
     "source": {
-      "$ref": "content"
+      "$ref": "contentcontainer"
     },
     "with": {
       "properties": {
@@ -316,7 +316,6 @@
                     "_navOrder": {
                       "type": "number",
                       "title": "Navigation bar order",
-                      "description": "Determines the order in which the object is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
                       "default": 100
                     }
                   }
@@ -334,7 +333,6 @@
                         "_navOrder": {
                           "type": "number",
                           "title": "Navigation bar order",
-                          "description": "Determines the order in which the object is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
                           "default": -100
                         }
                       }
@@ -347,7 +345,6 @@
                         "_navOrder": {
                           "type": "number",
                           "title": "Navigation bar order",
-                          "description": "Determines the order in which the object is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
                           "default": 0
                         }
                       }
@@ -366,7 +363,6 @@
                           "_navOrder": {
                             "type": "number",
                             "title": "Navigation bar order",
-                            "description": "Determines the order in which the object is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
                             "default": 0
                           }
                         }
@@ -583,28 +579,6 @@
                 "editorOnly": true
               }
             }
-          }
-        },
-        "tags": {
-          "type": "array",
-          "title": "Tags",
-          "description": "Add tags to your course by entering one or more words, separated with a comma (,)",
-          "items": {
-            "type": "string",
-            "isObjectId": true
-          },
-          "_adapt": {
-            "editorOnly": true
-          },
-          "_backboneForms": "Tags"
-        },
-        "_requireCompletionOf": {
-          "type": "number",
-          "title": "Number of pages/submenus required for completion",
-          "description": "The number of content objects within this course the learner must complete in order for this course to be set as completed. A value of -1 requires all of them to be completed",
-          "default": -1,
-          "_adapt": {
-            "isSetting": true
           }
         },
         "_isSelected": {


### PR DESCRIPTION
Discussion PR

[//]: # (Link the PR to the original issue)
#297

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
#### Update
* Tags property has been removed, as this is added via [a separate tags schema](https://github.com/adapt-security/adapt-authoring-tags/blob/master/schema/tags.schema.json)

#### New 
* Added `contentcontainer` schema, which is inherited from course/contentobject/artcile/block - name of the schema is open for suggestions
* Added `_supportedLayout` to component schema, which is used by all components (and almost never overridden)