### PR TITLE
New: Allow up, down, home, end, pageUp and pageDown to scroll popups (fixes #307)

### DIFF
--- a/js/a11y.js
+++ b/js/a11y.js
@@ -865,6 +865,14 @@ class A11y extends Backbone.Controller {
     return this._popup.setCloseTo($focusElement);
   }
 
+  get isPopupOpen() {
+    return this._popup.isOpen;
+  }
+
+  get popupStack() {
+    return this._popup.stack;
+  }
+
 }
 
 const a11y = new A11y();

--- a/js/a11y/popup.js
+++ b/js/a11y/popup.js
@@ -56,6 +56,14 @@ export default class Popup extends Backbone.Controller {
     });
   }
 
+  get isOpen() {
+    return (this._floorStack.length > 1);
+  }
+
+  get stack() {
+    return this._floorStack.slice(1);
+  }
+
   /**
    * Reorganise the tabindex and aria-hidden attributes in the document to
    * restrict user interaction to the element specified.

--- a/js/a11y/scroll.js
+++ b/js/a11y/scroll.js
@@ -4,7 +4,8 @@
  */
 export default class Scroll extends Backbone.Controller {
 
-  initialize() {
+  initialize({ a11y }) {
+    this._a11y = a11y;
     this._onTouchStart = this._onTouchStart.bind(this);
     this._onTouchEnd = this._onTouchEnd.bind(this);
     this._onScrollEvent = this._onScrollEvent.bind(this);
@@ -13,6 +14,10 @@ export default class Scroll extends Backbone.Controller {
     this.$window = $(window);
     this.$body = $('body');
     this._preventScrollOnKeys = {
+      33: true, // page up
+      34: true, // page down
+      35: true, // end
+      36: true, // home
       37: true, // left
       38: true, // up
       39: true, // right
@@ -123,8 +128,18 @@ export default class Scroll extends Backbone.Controller {
    */
   _onKeyDown(event) {
     event = $.event.fix(event);
-    if (!this._preventScrollOnKeys[event.keyCode]) {
+    if (!this._preventScrollOnKeys[event.which]) {
       return;
+    }
+    if (this._a11y.isPopupOpen && !this._isScrollable($(event.target))) {
+      const openPopup = this._a11y.popupStack[this._a11y.popupStack.length - 1];
+      const firstScrollable = this._isScrollable(openPopup)
+        ? openPopup
+        : this._a11y._findFirstForwardDescendant(openPopup, this._isScrollable);
+      if (firstScrollable.length) {
+        event.target = firstScrollable;
+      }
+
     }
     const $target = $(event.target);
     if ($target.is(this._ignoreKeysOnElementsMatching)) {
@@ -166,8 +181,9 @@ export default class Scroll extends Backbone.Controller {
    */
   _getScrollingParent(event, $target) {
     const isTouchEvent = event.type === 'touchmove';
+    const isKeyDownEvent = event.type === 'keydown';
     const hasTouchStartEvent = this._touchStartEventObject?.originalEvent;
-    if (isTouchEvent && !hasTouchStartEvent) {
+    if ((isTouchEvent && !hasTouchStartEvent) || !isKeyDownEvent) {
       return $target;
     }
     const directionY = this._getScrollDirection(event);
@@ -263,6 +279,7 @@ export default class Scroll extends Backbone.Controller {
   _getScrollDelta(event) {
     let deltaY = 0;
     const isTouchEvent = event.type === 'touchmove';
+    const isKeyDownEvent = event.type === 'keydown';
     const originalEvent = event.originalEvent;
     if (isTouchEvent) {
       // Touch events
@@ -277,6 +294,12 @@ export default class Scroll extends Backbone.Controller {
       }
       // Touch: delta calculated from touchstart pos vs touchmove pos
       deltaY = currentY - previousY;
+    } else if (isKeyDownEvent) {
+      deltaY = (event.which === 38 || event.which === 36 || event.which === 33)
+        ? 1
+        : (event.which === 40 || event.which === 35 || event.which === 34)
+          ? -1
+          : 0;
     } else {
       // Mouse events
       const hasDeltaY = (originalEvent.wheelDeltaY || originalEvent.deltaY !== undefined);

--- a/js/a11y/scroll.js
+++ b/js/a11y/scroll.js
@@ -295,9 +295,9 @@ export default class Scroll extends Backbone.Controller {
       // Touch: delta calculated from touchstart pos vs touchmove pos
       deltaY = currentY - previousY;
     } else if (isKeyDownEvent) {
-      deltaY = (event.which === 38 || event.which === 36 || event.which === 33)
+      deltaY = [33, 36, 38].includes(event.which)
         ? 1
-        : (event.which === 40 || event.which === 35 || event.which === 34)
+        : [34, 35, 40].includes(event.which)
           ? -1
           : 0;
     } else {

--- a/js/a11y/scroll.js
+++ b/js/a11y/scroll.js
@@ -132,14 +132,14 @@ export default class Scroll extends Backbone.Controller {
       return;
     }
     if (this._a11y.isPopupOpen && !this._isScrollable($(event.target))) {
-      const openPopup = this._a11y.popupStack[this._a11y.popupStack.length - 1];
-      const firstScrollable = this._isScrollable(openPopup)
-        ? openPopup
-        : this._a11y._findFirstForwardDescendant(openPopup, this._isScrollable);
-      if (firstScrollable.length) {
-        event.target = firstScrollable;
+      const $openPopup = this._a11y.popupStack[this._a11y.popupStack.length - 1];
+      const $firstScrollable = this._isScrollable($openPopup)
+        ? $openPopup
+        : this._a11y._findFirstForwardDescendant($openPopup, this._isScrollable);
+      if ($firstScrollable.length) {
+        // Correct the keydown event to the first scrollable region in the popup
+        event.target = $firstScrollable;
       }
-
     }
     const $target = $(event.target);
     if ($target.is(this._ignoreKeysOnElementsMatching)) {


### PR DESCRIPTION
fixes #307 

### Fix
* Allow up, down, home, end, pageUp and pageDown to scroll popups

### New
* Added `core/js/a11y` `isPopupOpen` and `popupStack`
