### PR TITLE
Fix: Set drawer position on multi-extension button menu view

### DIFF
--- a/js/views/drawerView.js
+++ b/js/views/drawerView.js
@@ -109,6 +109,7 @@ class DrawerView extends Backbone.View {
   }
 
   showDrawer(emptyDrawer) {
+    this.setDrawerPosition();
     this.$el.removeClass('u-display-none').removeAttr('aria-hidden');
     // Only trigger popup:opened if drawer is visible, pass popup manager drawer element
     if (!this._isVisible) {


### PR DESCRIPTION
fixes #312 

### Fix
* Drawer wasn't setting its position on multi-extension button menu view


