### PR TITLE
New: Update tracking logic to account for Scoring API

### DIFF
--- a/js/tracking.js
+++ b/js/tracking.js
@@ -20,70 +20,36 @@ class Tracking extends Backbone.Controller {
   setupEventListeners() {
     this.listenTo(Adapt, {
       'assessment:complete': this.onAssessmentComplete,
-      'assessment:restored': this.onAssessmentRestored
+      'assessment:restored': this.onAssessmentRestored,
+      'scoring:complete': this.onScoringComplete,
+      'scoring:restored': this.onScoringRestored
     });
 
-    // Check if completion requires completing all content.
     if (this._config._requireContentCompleted) {
       this.listenTo(Adapt.course, 'change:_isComplete', this.checkCompletion);
     }
   }
 
-  /**
-   * Store the assessment state.
-   * @param {object} assessmentState - The object returned by Adapt.assessment.getState()
-   */
-  onAssessmentComplete(assessmentState) {
-    this._assessmentState = assessmentState;
-
-    this.submitScore();
-    // Check if completion requires passing an assessment.
-    if (this._config._requireAssessmentCompleted) {
-      this.checkCompletion();
-    }
-  }
-
   submitScore() {
     if (!this._config._shouldSubmitScore) return;
-
-    if (this._assessmentState.isPercentageBased) {
-      offlineStorage.set('score', this._assessmentState.scoreAsPercent, 0, 100);
-      return;
-    }
-
-    offlineStorage.set('score', this._assessmentState.score, this._assessmentState.minScore, this._assessmentState.maxScore);
+    offlineStorage.set('score', this._assessmentState.score, this._assessmentState.minScore, this._assessmentState.maxScore, this._assessmentState.isPercentageBased);
   }
 
   /**
-   * Restores the _assessmentState object when an assessment is registered.
-   * @param {object} assessmentState - An object representing the overall assessment state
-   */
-  onAssessmentRestored(assessmentState) {
-    this._assessmentState = assessmentState;
-  }
-
-  /**
-   * Evaluate the course and assessment completion.
+   * Evaluate the course and assessment completion
    */
   checkCompletion() {
     const completionData = this.getCompletionData();
-
-    if (completionData.status === COMPLETION_STATE.INCOMPLETE) {
-      return;
-    }
-    
-    const canRetry = (completionData.assessment?.canRetry === true);
-    if (completionData.status === COMPLETION_STATE.FAILED && canRetry) {
-      return;
-    }
-
+    if (completionData.status === COMPLETION_STATE.INCOMPLETE) return;
+    const canRetry = completionData.assessment?.canRetry;
+    if (completionData.status === COMPLETION_STATE.FAILED && canRetry) return;
     Adapt.trigger('tracking:complete', completionData);
     logging.debug('tracking:complete', completionData);
   }
 
   /**
-   * The return value of this function should be passed to the trigger of 'tracking:complete'.
-   * @returns An object representing the user's course completion.
+   * The return value of this function should be passed to the trigger of 'tracking:complete'
+   * @returns An object representing the user's course completion
    */
   getCompletionData() {
     const completionData = {
@@ -91,34 +57,20 @@ class Tracking extends Backbone.Controller {
       assessment: null
     };
 
-    // Course complete is required.
-    if (this._config._requireContentCompleted && !Adapt.course.get('_isComplete')) {
-      // INCOMPLETE: course not complete.
-      return completionData;
-    }
-
-    // Assessment completed required.
+    if (this._config._requireContentCompleted && !Adapt.course.get('_isComplete')) return completionData;
     if (this._config._requireAssessmentCompleted) {
-      if (!this._assessmentState) {
-        // INCOMPLETE: assessment is not complete.
-        return completionData;
-      }
-
-      // PASSED/FAILED: assessment completed.
-      completionData.status = this._assessmentState.isPass ? COMPLETION_STATE.PASSED : COMPLETION_STATE.FAILED;
+      if (!this._assessmentState) return completionData;
+      const isPassed = this._assessmentState?.isPass ?? this._assessmentState?.isPassed;
+      completionData.status = isPassed ? COMPLETION_STATE.PASSED : COMPLETION_STATE.FAILED;
       completionData.assessment = this._assessmentState;
-
       return completionData;
     }
-
-    // COMPLETED: criteria met, no assessment requirements.
     completionData.status = COMPLETION_STATE.COMPLETED;
-
     return completionData;
   }
 
   /**
-   * Set the _config object to the values retrieved from config.json.
+   * Set the _config object to the values retrieved from config.json
    */
   loadConfig() {
     this._config = Adapt.config.get('_completionCriteria') ?? this._config;
@@ -127,6 +79,27 @@ class Tracking extends Backbone.Controller {
     // If the legacy property exists, use it for backward compatibility but warn in the console
     if (legacyShouldSubmitScore !== undefined) logging.deprecated('config.json:_spoor._tracking._shouldSubmitScore, please use only config.json:_completionCriteria._shouldSubmitScore');
     this._config._shouldSubmitScore = legacyShouldSubmitScore ?? newShouldSubmitScore ?? true;
+  }
+
+  onAssessmentComplete(assessmentState) {
+    // stop listening to `scoring:complete` if using Scoring API assessment backward compatibility
+    this.stopListening(Adapt, 'scoring:complete', this.onScoringComplete);
+    this.onScoringComplete(assessmentState);
+  }
+
+  onScoringComplete(state) {
+    this._assessmentState = state;
+    this.submitScore();
+    if (this._config._requireAssessmentCompleted) this.checkCompletion();
+  }
+
+  onAssessmentRestored(assessmentState) {
+    this.onScoringRestored(assessmentState);
+  }
+
+  onScoringRestored(state) {
+    if (this._assessmentState) return;
+    this._assessmentState = state;
   }
 
 }

--- a/js/tracking.js
+++ b/js/tracking.js
@@ -9,6 +9,7 @@ class Tracking extends Backbone.Controller {
     this._config = {
       _requireContentCompleted: true,
       _requireAssessmentCompleted: false,
+      _submitOnEveryAssessmentAttempt: false,
       _shouldSubmitScore: false
     };
     this._assessmentState = null;
@@ -42,7 +43,7 @@ class Tracking extends Backbone.Controller {
     const completionData = this.getCompletionData();
     if (completionData.status === COMPLETION_STATE.INCOMPLETE) return;
     const canRetry = completionData.assessment?.canRetry;
-    if (completionData.status === COMPLETION_STATE.FAILED && canRetry) return;
+    if (!this._config._submitOnEveryAssessmentAttempt && completionData.status === COMPLETION_STATE.FAILED && canRetry) return;
     Adapt.trigger('tracking:complete', completionData);
     logging.debug('tracking:complete', completionData);
   }
@@ -73,7 +74,7 @@ class Tracking extends Backbone.Controller {
    * Set the _config object to the values retrieved from config.json
    */
   loadConfig() {
-    this._config = Adapt.config.get('_completionCriteria') ?? this._config;
+    Object.assign(this._config, Adapt.config.get('_completionCriteria'));
     const newShouldSubmitScore = this._config._shouldSubmitScore;
     const legacyShouldSubmitScore = Adapt.config.get('_spoor')?._tracking?._shouldSubmitScore;
     // If the legacy property exists, use it for backward compatibility but warn in the console

--- a/schema/config.model.schema
+++ b/schema/config.model.schema
@@ -39,7 +39,15 @@
           "inputType": "Checkbox",
           "validators": [],
           "title": "Require assessment completion",
-          "help": "Specifies that all assessments on the course must be completed"
+          "help": "Specifies that the assessment must be completed"
+        },
+        "_submitOnEveryAssessmentAttempt": {
+          "type": "boolean",
+          "default": false,
+          "inputType": "Checkbox",
+          "validators": [],
+          "title": "Submit completion on every assessment attempt",
+          "help": "Specifies that the completion status will be reported every time the assessment is completed (regardless of whether the user passes or fails), assuming the course completion criteria is met"
         }
       }
     },

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -48,10 +48,16 @@
           "title": "Require all assessments to be completed",
           "default": false
         },
+        "_submitOnEveryAssessmentAttempt": {
+          "type": "boolean",
+          "title": "Submit completion on every assessment attempt",
+          "description": "If enabled and the course completion criteria is met, the completion status will be reported every time the assessment is completed (regardless of whether the user passes or fails)",
+          "default": false
+        },
         "_shouldSubmitScore": {
           "type": "boolean",
           "title": "Submit score to LMS",
-          "description": "If enabled, the score attained in any assessment will be reported (regardless of whether the user passes or fails the assessment)",
+          "description": "If enabled, the score attained in any assessment attempt will be reported (regardless of whether the user passes or fails)",
           "default": false
         }
       }


### PR DESCRIPTION
Fixes #112 
Fixes https://github.com/adaptlearning/adapt-contrib-spoor/issues/262

### New
* Update tracking logic to account for [Scoring API](https://github.com/adaptlearning/adapt-contrib-scoring)

### Fix
* Allow `tracking:complete` to be triggered for every assessment attempt, if required


