### PR TITLE
New: Add icon span to instruction element in header.jsx (fixes #328)

### DIFF
--- a/templates/header.jsx
+++ b/templates/header.jsx
@@ -73,6 +73,7 @@ export default function Header(props) {
 
         {sizedInstruction &&
         <div className={prefixClasses(classNamePrefixes, ['__instruction'])}>
+          <span className="icon" aria-hidden="true" />
           <div className={prefixClasses(classNamePrefixes, ['__instruction-inner'])} dangerouslySetInnerHTML={{ __html: compile(sizedInstruction, props) }}>
           </div>
         </div>

--- a/templates/partials/component.hbs
+++ b/templates/partials/component.hbs
@@ -23,6 +23,7 @@
 
     {{#any instruction mobileInstruction}}
     <div class="component__instruction {{lowercase _component}}__instruction">
+      <span class="icon" aria-hidden="true"></span>
       <div class="component__instruction-inner {{lowercase _component}}__instruction-inner">
         {{{compile instruction}}}
       </div>


### PR DESCRIPTION
Fixes #328 

### New
* Adds a `span` element with an `icon` class. This can be used to show an icon when, for instance, the instruction text should be highlighted as an error.

### Testing
Can be tested along with https://github.com/adaptlearning/adapt-contrib-narrative/pull/250 .
1. Add a Narrative component
2. On mobile, click the Next button without first clicking on the strapline button.

<img src="https://user-images.githubusercontent.com/898168/224845404-4965f978-2b3f-4437-87cc-d7d3df5e52ca.jpg" width="350">

### Notes

- All styling for this error message / icon currently lives in the Narrative component's Less. We could consider moving it to the theme or core styles, though.
