### PR TITLE
New: Added Navigation Button API

### DIFF
--- a/js/models/NavigationButtonModel.js
+++ b/js/models/NavigationButtonModel.js
@@ -1,0 +1,14 @@
+import LockingModel from 'core/js/models/lockingModel';
+
+export default class NavigationButtonModel extends LockingModel {
+
+  defaults() {
+    return {
+      _id: '',
+      _order: 0,
+      _event: '',
+      text: '{{ariaLabel}}'
+    };
+  }
+
+}

--- a/js/models/NavigationModel.js
+++ b/js/models/NavigationModel.js
@@ -1,0 +1,13 @@
+import LockingModel from 'core/js/models/lockingModel';
+
+export default class NavigationModel extends LockingModel {
+
+  defaults() {
+    return {
+      _navigationAlignment: 'top',
+      _isBottomOnTouchDevices: false,
+      _showLabel: false
+    };
+  }
+
+}

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -1,37 +1,23 @@
 import Adapt from 'core/js/adapt';
 import NavigationView from 'core/js/views/navigationView';
-import device from './device';
+import NavigationModel from './models/NavigationModel';
 
 class NavigationController extends Backbone.Controller {
 
   initialize() {
-    this.listenTo(Adapt, {
-      'adapt:preInitialize': this.addNavigationBar,
-      'adapt:preInitialize device:resize': this.onDeviceResize
-    });
+    this.navigation = new NavigationView();
+    this.listenTo(Adapt, 'adapt:preInitialize', this.addNavigationBar);
   }
 
   addNavigationBar() {
     const adaptConfig = Adapt.course.get('_navigation');
-
     if (adaptConfig?._isDefaultNavigationDisabled) {
       Adapt.trigger('navigation:initialize');
       return;
     }
-
-    Adapt.navigation = new NavigationView();// This should be triggered after 'app:dataReady' as plugins might want to manipulate the navigation
-  }
-
-  onDeviceResize() {
-    const adaptConfig = Adapt.course.get('_navigation');
-    const $html = $('html');
-    $html.addClass('is-nav-top');
-    let navigationAlignment = adaptConfig?._navigationAlignment ?? 'top';
-    const isBottomOnTouchDevices = (device.touch && adaptConfig?._isBottomOnTouchDevices);
-    if (isBottomOnTouchDevices) navigationAlignment = 'bottom';
-    $html.removeClass('is-nav-top').addClass('is-nav-' + navigationAlignment);
+    this.navigation.start(new NavigationModel(adaptConfig));
   }
 
 }
 
-export default new NavigationController();
+export default (Adapt.navigation = (new NavigationController()).navigation);

--- a/js/views/NavigationButtonView.js
+++ b/js/views/NavigationButtonView.js
@@ -1,0 +1,151 @@
+import Adapt from 'core/js/adapt';
+import wait from 'core/js/wait';
+import { compile, templates } from 'core/js/reactHelpers';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import router from 'core/js/router';
+import startController from 'core/js/startController';
+import a11y from 'core/js/a11y';
+import location from 'core/js/location';
+
+export default class NavigationButtonView extends Backbone.View {
+
+  events() {
+    return {
+      click: 'triggerEvent'
+    };
+  }
+
+  className() {
+    return '';
+  }
+
+  attributes() {
+    const attributes = this.model.toJSON();
+    return {
+      'data-order': attributes._order,
+      'data-event': attributes._event
+    };
+  }
+
+  initialize({ el }) {
+    if (el) {
+      this.isInjectedButton = true;
+    } else {
+      this.isJSX = (this.constructor.template || '').includes('.jsx');
+    }
+    this._classSet = new Set(_.result(this, 'className').trim().split(/\s+/));
+    this._attributes = _.result(this, 'attributes');
+    this.listenTo(this.model, 'change', this.changed);
+    this.render();
+  }
+
+  static template() {
+    return 'navigation-button.jsx';
+  }
+
+  render() {
+    if (this.isInjectedButton) {
+      this.changed();
+    } else if (this.isJSX) {
+      this.changed();
+    } else {
+      const data = this.model.toJSON();
+      data.view = this;
+      const template = Handlebars.templates[this.constructor.template];
+      this.$el.html(template(data));
+    }
+    return this;
+  }
+
+  updateViewProperties() {
+    const classesToAdd = _.result(this, 'className').trim().split(/\s+/);
+    classesToAdd.forEach(i => this._classSet.add(i));
+    const classesToRemove = [ ...this._classSet ].filter(i => !classesToAdd.includes(i));
+    classesToRemove.forEach(i => this._classSet.delete(i));
+    Object.keys(this._attributes).forEach(name => this.$el.removeAttr(name));
+    Object.entries(_.result(this, 'attributes')).forEach(([name, value]) => this.$el.attr(name, value));
+    this.$el.removeClass(classesToRemove).addClass(classesToAdd);
+  }
+
+  injectLabel() {
+    const textLabel = this.$el.find('> .label');
+    const ariaLabel = this.$el.attr('aria-label') ?? this.$el.find('.aria-label').text();
+    const text = this.model.get('text');
+    const output = compile(text ?? '', { ariaLabel });
+    if (!textLabel.length) {
+      this.$el.append(`<span class="label" aria-hidden="true">${output}</span>`);
+      return;
+    }
+    textLabel.html(output);
+  }
+
+  /**
+   * Re-render a react template
+   * @param {string} eventName=null Backbone change event name
+   */
+  changed(eventName = null) {
+    if (typeof eventName === 'string' && eventName.startsWith('bubble')) {
+      // Ignore bubbling events as they are outside of this view's scope
+      return;
+    }
+    if (this.isInjectedButton) {
+      this.updateViewProperties();
+      this.injectLabel();
+      return;
+    }
+    if (!this.isJSX) {
+      this.updateViewProperties();
+      return;
+    }
+    const props = {
+      // Add view own properties, bound functions etc
+      ...this,
+      // Add model json data
+      ...this.model.toJSON(),
+      // Add globals
+      _globals: Adapt.course.get('_globals')
+    };
+    const Template = templates[this.constructor.template.replace('.jsx', '')];
+    this.updateViewProperties();
+    ReactDOM.render(<Template {...props} />, this.el);
+  }
+
+  triggerEvent(event) {
+    event.preventDefault();
+    const currentEvent = $(event.currentTarget).attr('data-event');
+    if (!currentEvent) return;
+    Adapt.trigger('navigation:' + currentEvent);
+    switch (currentEvent) {
+      case 'backButton':
+        router.navigateToPreviousRoute();
+        break;
+      case 'homeButton':
+        router.navigateToHomeRoute();
+        break;
+      case 'parentButton':
+        router.navigateToParent();
+        break;
+      case 'skipNavigation':
+        a11y.focusFirst('.' + location._contentType);
+        break;
+      case 'returnToStart':
+        startController.returnToStartLocation();
+        break;
+    }
+  }
+
+  remove() {
+    this._isRemoved = true;
+    this.stopListening();
+    wait.for(end => {
+      if (this.isJSX) {
+        ReactDOM.unmountComponentAtNode(this.el);
+      }
+      super.remove();
+      end();
+    });
+    return this;
+  }
+
+}

--- a/js/views/adaptView.js
+++ b/js/views/adaptView.js
@@ -27,9 +27,9 @@ class AdaptView extends Backbone.View {
     this.isJSX = (this.constructor.template || '').includes('.jsx');
     if (this.isJSX) {
       this._classSet = new Set(_.result(this, 'className').trim().split(/\s+/));
-      this.listenTo(this.model, 'all', this.changed);
+      this.listenTo(this.model, 'change', this.changed);
       const children = this.model?.getChildren?.();
-      children && this.listenTo(children, 'all', this.changed);
+      children && this.listenTo(children, 'change', this.changed);
       // Facilitate adaptive react views
       this.listenTo(Adapt, 'device:changed', this.changed);
     }
@@ -205,7 +205,7 @@ class AdaptView extends Backbone.View {
    */
   addChildView(childView) {
     const childModel = childView.model;
-    const type = childModel.get('_type')
+    const type = childModel.get('_type');
     const childViews = this.getChildViews() || [];
     childViews.push(childView);
     this.setChildViews(childViews);

--- a/js/views/navigationView.js
+++ b/js/views/navigationView.js
@@ -1,20 +1,16 @@
 import Adapt from 'core/js/adapt';
-import a11y from 'core/js/a11y';
-import location from 'core/js/location';
-import router from 'core/js/router';
-import startController from 'core/js/startController';
+import device from 'core/js/device';
 import _ from 'underscore';
+import NavigationButtonView from './NavigationButtonView';
+import NavigationButtonModel from '../models/NavigationButtonModel';
 
 class NavigationView extends Backbone.View {
 
   className() {
-    return 'nav';
-  }
-
-  events() {
-    return {
-      'click [data-event]': 'triggerEvent'
-    };
+    return [
+      'nav',
+      this.model?.get('_showLabel') && 'show-label'
+    ].join(' ');
   }
 
   attributes() {
@@ -23,11 +19,48 @@ class NavigationView extends Backbone.View {
     };
   }
 
+  get buttons() {
+    return (this._buttons = this._buttons || []);
+  }
+
+  set buttons(value) {
+    this._buttons = value;
+  }
+
   initialize() {
     _.bindAll(this, 'sortNavigationButtons');
+    this._classSet = new Set(_.result(this, 'className').trim().split(/\s+/));
+  }
+
+  start(model) {
+    this.model = model;
+    this.listenTo(model, 'change', this.update);
     this.listenToOnce(Adapt, 'courseModel:dataLoading', this.remove);
-    this.listenTo(Adapt, 'router:menu router:page', this.hideNavigationButton);
+    this.listenTo(Adapt, {
+      'router:contentObject': this.hideNavigationButton,
+      'adapt:preInitialize device:resize': this.onDeviceResize
+    });
+    this.update();
     this.preRender();
+  }
+
+  update() {
+    this.updateViewProperties();
+    this.onDeviceResize();
+  }
+
+  onDeviceResize() {
+    let {
+      _navigationAlignment,
+      _isBottomOnTouchDevices
+    } = this.model.toJSON();
+    const $html = $('html');
+    $html.addClass('is-nav-top');
+    const isBottomOnTouchDevices = (device.touch && _isBottomOnTouchDevices);
+    if (isBottomOnTouchDevices) _navigationAlignment = 'bottom';
+    $html
+      .removeClass('is-nav-top is-nav-bottom')
+      .addClass('is-nav-' + _navigationAlignment);
   }
 
   preRender() {
@@ -42,66 +75,132 @@ class NavigationView extends Backbone.View {
       _globals: Adapt.course.get('_globals'),
       _accessibility: Adapt.config.get('_accessibility')
     })).insertBefore('#app');
-    this.listenForInjectedButtons();
+    this.sortNavigationButtons();
     _.defer(() => {
       Adapt.trigger('navigationView:postRender', this);
     });
-
     return this;
   }
 
-  triggerEvent(event) {
-    event.preventDefault();
-    const currentEvent = $(event.currentTarget).attr('data-event');
-    Adapt.trigger('navigation:' + currentEvent);
-    switch (currentEvent) {
-      case 'backButton':
-        router.navigateToPreviousRoute();
-        break;
-      case 'homeButton':
-        router.navigateToHomeRoute();
-        break;
-      case 'parentButton':
-        router.navigateToParent();
-        break;
-      case 'skipNavigation':
-        this.skipNavigation();
-        break;
-      case 'returnToStart':
-        startController.returnToStartLocation();
-        break;
-    }
-  }
-
-  skipNavigation() {
-    a11y.focusFirst('.' + location._contentType);
-  }
-
-  hideNavigationButton(model) {
-    const shouldHide = (model.get('_type') === 'course');
-    this.$('.nav__back-btn, .nav__home-btn').toggleClass('u-display-none', shouldHide);
+  updateViewProperties() {
+    const classesToAdd = _.result(this, 'className').trim().split(/\s+/);
+    classesToAdd.forEach(i => this._classSet.add(i));
+    const classesToRemove = [ ...this._classSet ].filter(i => !classesToAdd.includes(i));
+    classesToRemove.forEach(i => this._classSet.delete(i));
+    this._setAttributes({ ..._.result(this, 'attributes'), id: _.result(this, 'id') });
+    this.$el.removeClass(classesToRemove).addClass(classesToAdd);
   }
 
   listenForInjectedButtons() {
     this.observer = this.observer || new MutationObserver(this.sortNavigationButtons);
     this.observer.observe(this.$('.nav__inner')[0], {
-      childList: true
+      childList: true,
+      attributes: true,
+      subtree: true
     });
   }
 
-  sortNavigationButtons() {
-    this.observer.disconnect();
-    const container = this.$('.nav__inner')[0];
-    const items = [...container.children];
-    items
-      .sort((a, b) => parseFloat($(a).attr('data-order') || 0) - parseFloat($(b).attr('data-order') || 0))
-      .forEach(item => container.appendChild(item));
-    this.observer.takeRecords();
+  sortNavigationButtons(changed) {
+    if (Array.isArray(changed)) {
+      // Summarize mutation observer changes
+      const changes = Object.entries(changed.reduce((changes, change) => {
+        const changeTypeName = `${change.type}.${change.attributeName}`;
+        changes[changeTypeName] = changes[changeTypeName] || 0;
+        changes[changeTypeName]++;
+        return changes;
+      }, {}));
+      // Ignore blur event changes as this will interrupt focus assignment
+      const shouldIgnore = changes.every(([key]) => [
+        'attributes.data-a11y-force-focus',
+        'attributes.tabindex',
+        'attributes.aria-hidden',
+        'attributes.aria-expanded'
+      ].includes(key));
+      if (shouldIgnore) return;
+    }
+    this.observer?.disconnect();
+    const $container = this.$('.nav__inner');
+    const items = [...$container[0].children];
+    const identifiers = {
+      '.js-nav-drawer-btn': 'drawer',
+      '.js-nav-back-btn': 'back',
+      '.js-nav-home-btn': 'home',
+      '*': null
+    };
+    // Capture existing children and make models and views for any which
+    //  weren't registered in the api.
+    items.forEach(el => {
+      const $el = $(el);
+      // Ignore spacers
+      if ($el.is('.nav__spacer')) return;
+      // Try to generate an id
+      const foundId = (
+        $el.attr('name') ??
+        Object.entries(identifiers).find(([classes]) => $el.is(classes))?.[1]
+      ) || $el.attr('class');
+      const attributes = {
+        _id: foundId,
+        _order: parseFloat($el.attr('data-order') || 0),
+        _event: $el.attr('data-event')
+      };
+      const existingButton = this.getButton(attributes._id);
+      if (existingButton) {
+        if (!existingButton.isInjectedButton) return;
+        if (existingButton.el !== el) {
+          // Update injected buttons with new element if necessary
+          existingButton.undelegateEvents();
+          existingButton.el = el;
+          existingButton.$el = $(el);
+          existingButton.delegateEvents();
+        }
+        // Attempt to render changes on inject buttons
+        existingButton.model.set(attributes);
+        existingButton.changed();
+        return;
+      };
+      // Add missing buttons
+      const navigationButtonModel = new NavigationButtonModel(attributes);
+      this.addButton(new NavigationButtonView({
+        el,
+        model: navigationButtonModel
+      }));
+    });
+    // Sort items and add to dom in sorted order
+    //   Make sure not to move any item with focus as it will lose focus
+    const focusElement = document.activeElement;
+    items.sort((a, b) => parseFloat($(a).attr('data-order') || 0) - parseFloat($(b).attr('data-order') || 0));
+    let indexOfFocused = items.findIndex(el => el === focusElement);
+    if (indexOfFocused === -1) indexOfFocused = Infinity;
+    const before = items.slice(0, indexOfFocused);
+    const after = items.slice(indexOfFocused + 1);
+    before.reverse().forEach(el => $container.prepend(el));
+    after.forEach(el => $container.append(el));
+    this.observer?.takeRecords();
     this.listenForInjectedButtons();
+  }
+
+  hideNavigationButton(contentObjectModel) {
+    const shouldHide = (contentObjectModel.get('_type') === 'course');
+    this.$('.nav__back-btn, .nav__home-btn').toggleClass('u-display-none', shouldHide);
   }
 
   showNavigationButton() {
     this.$('.nav__back-btn, .nav__home-btn').removeClass('u-display-none');
+  }
+
+  addButton(buttonView) {
+    this.buttons.push(buttonView);
+    const container = this.$('.nav__inner');
+    container.append(buttonView.$el);
+    this.listenTo(buttonView.model, 'change', this.sortNavigationButtons);
+  }
+
+  getButton(id) {
+    return this.buttons.find(button => button.model.get('_id') === id);
+  }
+
+  removeButton(buttonView) {
+    this.buttons = this.buttons.filter(view => view !== buttonView);
   }
 
 }

--- a/less/core/nav.less
+++ b/less/core/nav.less
@@ -34,6 +34,15 @@ html.is-nav-bottom #wrapper {
     float: none !important;
   }
 
+  &__btn > .label {
+    display: none;
+  }
+
+  &.show-label &__btn > .label,
+  &__btn.show-label > .label {
+    display: initial;
+  }
+
   &__spacer {
     flex-grow: 1;
   }

--- a/templates/nav.hbs
+++ b/templates/nav.hbs
@@ -5,21 +5,23 @@
 <div class="nav__inner">
 
   {{#if _accessibility._isSkipNavigationEnabled}}
-  <button class="btn-text nav__btn nav__skip-btn" data-event="skipNavigation" aria-label="{{_globals._accessibility._ariaLabels.skipNavigation}}" data-order="{{_globals._extensions._navigation._skipButton._navOrder}}">
-    {{{_globals._accessibility.skipNavigationText}}}
+  <button name="skipButton" class="btn-icon nav__btn nav__skip-btn show-label" data-event="skipNavigation" aria-label="{{_globals._accessibility._ariaLabels.skipNavigation}}" data-order="{{_globals._extensions._navigation._skipButton._navOrder}}">
+    <span class='label' aria-hidden="true">{{_globals._accessibility.skipNavigationText}}</span>
   </button>
   {{/if}}
 
-  <button class="btn-icon nav__btn nav__back-btn js-nav-back-btn u-display-none" data-event="backButton" aria-label="{{_globals._accessibility._ariaLabels.previous}}" role="link" data-order="{{_globals._extensions._navigation._backButton._navOrder}}">
+  <button name="backButton" class="btn-icon nav__btn nav__back-btn js-nav-back-btn u-display-none" data-event="backButton" aria-label="{{_globals._accessibility._ariaLabels.previous}}" role="link" data-order="{{_globals._extensions._navigation._backButton._navOrder}}">
     <span class="icon" aria-hidden="true"></span>
+    <span class='label' aria-hidden="true">{{_globals._accessibility._ariaLabels.previous}}</span>
   </button>
 
   {{#each _globals._extensions._navigation._spacers}}
     <div class="nav__spacer" aria-hidden="true" data-order="{{_navOrder}}"></div>
   {{/each}}
 
-  <button class="btn-icon nav__btn nav__drawer-btn js-nav-drawer-btn is-position-{{_config._drawer._position}}" data-event="toggleDrawer" aria-expanded="false" aria-label="{{_globals._accessibility._ariaLabels.navigationDrawer}}" data-order="{{_globals._extensions._drawer._navOrder}}">
+  <button name="drawer" class="btn-icon nav__btn nav__drawer-btn js-nav-drawer-btn is-position-{{_config._drawer._position}}" data-event="toggleDrawer" aria-expanded="false" aria-label="{{_globals._accessibility._ariaLabels.navigationDrawer}}" data-order="{{_globals._extensions._drawer._navOrder}}">
     <span class="icon" aria-hidden="true"></span>
+    <span class='label' aria-hidden="true">{{_globals._accessibility._ariaLabels.navigationDrawer}}</span>
   </button>
 
 </div>


### PR DESCRIPTION
fixes #338 

### New
* `NavigationButtonModel` To hold the properties for each button
* `NavigationButtonView` For extensions to make their own buttons and for legacy injected button management
* `NavigationModel` To hold the navigation configuration
* All model updates will be reflected in the DOM.

General API layout:
```js
import navigation from 'core/js/navigation';
navigation.model.set('_showLabel', true); // Show all labels
const instance = navigation.getButton('back');
instance.set('_order', 400); // Move the back button to the right
instance.set('text', 'New Label');; // Change the back button label text
navigation.removeButton(instance);
// Remove all buttons
navigation.buttons.forEach(button => navigation.removeButton(button));
```

To make a home button:

![image](https://user-images.githubusercontent.com/7974663/228893292-c4737ad4-a768-437e-9075-ca3f5481fcc8.png)

```js
import Adapt from 'core/js/adapt';
import navigation from 'core/js/navigation';
import NavigationButtonModel from 'core/js/models/NavigationButtonModel';
import NavigationButtonView from 'core/js/views/NavigationButtonView';

// Extend the model and view classes to add own behaviour

Adapt.on('navigation:ready', () => {
  const model = new NavigationButtonModel({
    _id: 'home',
    _order: 0,
    _event: 'homeButton',
    _showLabel: null,
    _classes: '',
    _iconClasses: 'icon-medal',
    _role: 'link',
    ariaLabel: 'Home',
    text: '{{ariaLabel}}'
  });
  const view = new NavigationButtonView({ model });
  navigation.addButton(view);
});
```

`_eventName` has some default behaviour at `"backButton"`, `"homeButton"`, `"parentButton"`, `"skipNavigation"` and `"returnToStart"`.


### Testing
In the console it is possible to use:
1. `require('core/js/navigation').model.set('_showLabel', true);`
2. `require('core/js/navigation').getButton('back').set('_order', 400);`
3. `require('core/js/navigation').getButton('back').set('text', 'New Label');`

