### PR TITLE
Fix: ChildView API broken

### DIFF
--- a/js/views/adaptView.js
+++ b/js/views/adaptView.js
@@ -205,7 +205,7 @@ class AdaptView extends Backbone.View {
    */
   addChildView(childView) {
     const childModel = childView.model;
-    const type = childModel.get('_type')
+    const type = childModel.get('_type');
     const childViews = this.getChildViews() || [];
     childViews.push(childView);
     this.setChildViews(childViews);
@@ -295,6 +295,7 @@ class AdaptView extends Backbone.View {
         return;
       }
       // A new model has been supplied for the end of the list.
+      model = event.model;
     }
     const type = model.get('_type');
     // Trigger an event to signify that a new model is to be added


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt-contrib-branching/issues/43

### Fix
* Previous [pr](https://github.com/adaptlearning/adapt-contrib-core/pull/281) broke API where variable `model` doesn't exist.
https://github.com/adaptlearning/adapt-contrib-core/blob/3668a15c1e9777c23615746cd1d8465f9d729a27/js/views/adaptView.js#L299
