### PR TITLE
Fix: Safari label click for input

### DIFF
--- a/js/fixes.js
+++ b/js/fixes.js
@@ -1,2 +1,3 @@
 import 'core/js/fixes/img.lazyload';
 import 'core/js/fixes/reactHelpers.html';
+import 'core/js/fixes/safari.label.click.blur';

--- a/js/fixes/safari.label.click.blur.js
+++ b/js/fixes/safari.label.click.blur.js
@@ -17,7 +17,7 @@ import 'core/js/templates';
 
 Adapt.on('app:dataReady', () => {
   const config = Adapt.config.get('_fixes');
-  if (config?._jsxReactHelpersHTML === false) return;
+  if (config?._safariLabelClickBlur === false) return;
   applySafariLabelClickBlur();
 });
 

--- a/js/fixes/safari.label.click.blur.js
+++ b/js/fixes/safari.label.click.blur.js
@@ -1,0 +1,34 @@
+import Adapt from 'core/js/adapt';
+import 'core/js/templates';
+
+/**
+  In Safari, a click triggers a mousedown, a blur, a mouseup, a focus, then a click,
+  which is different from chrome-based browsers.
+  Sometimes we rerender the template on a blur, the rerender prevents
+  the click event from firing in Safari, instead of allowing click to fall through from
+  the label to the input, we prevent the label click and instead
+  trigger a manual click on the input referenced by the label's for attribute.
+  This fixes the issue in both the iOS and MacOS versions of Safari
+  References:
+    https://www.eventbrite.com/engineering/a-story-of-a-react-re-rendering-bug/
+    https://sitr.us/2011/07/28/how-mobile-safari-emulates-mouse-events.html
+    https://stackoverflow.com/questions/9335325/blur-event-stops-click-event-from-working
+ */
+
+Adapt.on('app:dataReady', () => {
+  const config = Adapt.config.get('_fixes');
+  if (config?._jsxReactHelpersHTML === false) return;
+  applySafariLabelClickBlur();
+});
+
+function applySafariLabelClickBlur() {
+  Adapt.on('reactElement:preRender', event => {
+    const [tagName, props] = event.args;
+    if (tagName !== 'label' && !Object.hasOwn(props, 'for') && !Object.hasOwn(props, 'onClick')) return;
+    props.onClick = event => {
+      event.preventDefault();
+      const input = document.querySelector(`#${event.currentTarget.getAttribute('for')}`);
+      input.click();
+    };
+  });
+}

--- a/js/fixes/safari.label.click.blur.js
+++ b/js/fixes/safari.label.click.blur.js
@@ -30,7 +30,7 @@ function onLabelClick (event) {
 function applySafariLabelClickBlur () {
   Adapt.on('reactElement:preRender', event => {
     const [tagName, props] = event.args;
-    if (tagName !== 'label' || !Object.hasOwn(props, 'for') || Object.hasOwn(props, 'onClick')) return;
+    if (tagName !== 'label' || !Object.hasOwn(props, 'htmlFor') || Object.hasOwn(props, 'onClick')) return;
     props.onClick = onLabelClick;
   });
 }

--- a/js/fixes/safari.label.click.blur.js
+++ b/js/fixes/safari.label.click.blur.js
@@ -21,14 +21,16 @@ Adapt.on('app:dataReady', () => {
   applySafariLabelClickBlur();
 });
 
-function applySafariLabelClickBlur() {
+function onLabelClick (event) {
+  event.preventDefault();
+  const input = document.querySelector(`#${event.currentTarget.getAttribute('for')}`);
+  input.click();
+};
+
+function applySafariLabelClickBlur () {
   Adapt.on('reactElement:preRender', event => {
     const [tagName, props] = event.args;
     if (tagName !== 'label' && !Object.hasOwn(props, 'for') && !Object.hasOwn(props, 'onClick')) return;
-    props.onClick = event => {
-      event.preventDefault();
-      const input = document.querySelector(`#${event.currentTarget.getAttribute('for')}`);
-      input.click();
-    };
+    props.onClick = onLabelClick;
   });
 }

--- a/js/fixes/safari.label.click.blur.js
+++ b/js/fixes/safari.label.click.blur.js
@@ -30,7 +30,7 @@ function onLabelClick (event) {
 function applySafariLabelClickBlur () {
   Adapt.on('reactElement:preRender', event => {
     const [tagName, props] = event.args;
-    if (tagName !== 'label' && !Object.hasOwn(props, 'for') && !Object.hasOwn(props, 'onClick')) return;
+    if (tagName !== 'label' || !Object.hasOwn(props, 'for') || Object.hasOwn(props, 'onClick')) return;
     props.onClick = onLabelClick;
   });
 }


### PR DESCRIPTION
fixes #350 

### Fix
* General fix for safari label clicks to redirected the label click, to an input click, which overcomes complex brower+react bug


### Testing
Please test on ios and macos safari and on windows chrome, edge and firefox if you can.
Requires https://github.com/adaptlearning/adapt-contrib-mcq/pull/206
