### PR TITLE
Fix: _shouldResetAllAnswers moved into core from matching

### DIFF
--- a/js/models/itemsQuestionModel.js
+++ b/js/models/itemsQuestionModel.js
@@ -192,8 +192,11 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
   }
 
   resetItems() {
-    if (this.get('_shouldResetAllAnswers')) this.resetActiveItems();
-    else this.resetIncorrectItems();
+    if (this.get('_shouldResetAllAnswers') === false) {
+      this.resetIncorrectItems();
+    } else {
+      this.resetActiveItems();
+    }
     this.set('_isAtLeastOneCorrectSelection', false);
   }
 

--- a/js/models/itemsQuestionModel.js
+++ b/js/models/itemsQuestionModel.js
@@ -194,9 +194,9 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
   resetItems() {
     if (this.get('_shouldResetAllAnswers') === false) {
       this.resetIncorrectItems();
-    } else {
-      this.resetActiveItems();
+      return;
     }
+    this.resetActiveItems();
     this.set('_isAtLeastOneCorrectSelection', false);
   }
 
@@ -206,6 +206,7 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
       if (isCorrect) return;
       item.toggleActive(false);
     });
+    this.set('_isAtLeastOneCorrectSelection', Boolean(this.getLastActiveItem()));
   }
 
   getInteractionObject() {

--- a/js/models/itemsQuestionModel.js
+++ b/js/models/itemsQuestionModel.js
@@ -192,8 +192,17 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
   }
 
   resetItems() {
-    this.resetActiveItems();
+    if (this.get('_shouldResetAllAnswers')) this.resetActiveItems();
+    else this.resetIncorrectItems();
     this.set('_isAtLeastOneCorrectSelection', false);
+  }
+
+  resetIncorrectItems() {
+    this.getChildren().each(item => {
+      const isCorrect = (item.get('_shouldBeSelected') || item.get('_isCorrect'));
+      if (isCorrect) return;
+      item.toggleActive(false);
+    });
   }
 
   getInteractionObject() {


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt-contrib-matching/issues/171

Allows only incorrect answers to reset instead of all answers.

### Fix
* Added `_shouldResetAllAnswers ` as an `ItemsQuestionModel` settings



