### PR TITLE
Fix: Safari fix invalid AAT ids (fixes #353)

### DIFF
--- a/js/fixes/safari.label.click.blur.js
+++ b/js/fixes/safari.label.click.blur.js
@@ -22,8 +22,9 @@ Adapt.on('app:dataReady', () => {
 });
 
 function onLabelClick (event) {
+  const input = document.querySelector(`[id="${event.currentTarget.getAttribute('for')}"]`);
+  if (!input) return;
   event.preventDefault();
-  const input = document.querySelector(`#${event.currentTarget.getAttribute('for')}`);
   input.click();
 };
 


### PR DESCRIPTION
fixes #353 

### Fix
* Allow browser to search for elements by id when using invalid AAT ids
* Prevent any other click-crash if specified id cannot be found

