### PR TITLE
Fix: Scroll background from popups

### DIFF
--- a/js/a11y/scroll.js
+++ b/js/a11y/scroll.js
@@ -183,7 +183,7 @@ export default class Scroll extends Backbone.Controller {
     const isTouchEvent = event.type === 'touchmove';
     const isKeyDownEvent = event.type === 'keydown';
     const hasTouchStartEvent = this._touchStartEventObject?.originalEvent;
-    if ((isTouchEvent && !hasTouchStartEvent) || !isKeyDownEvent) {
+    if ((isTouchEvent && !hasTouchStartEvent) && !isKeyDownEvent) {
       return $target;
     }
     const directionY = this._getScrollDirection(event);

--- a/js/a11y/scroll.js
+++ b/js/a11y/scroll.js
@@ -26,6 +26,12 @@ export default class Scroll extends Backbone.Controller {
     this._ignoreKeysOnElementsMatching = 'textarea, input, select';
     this._isRunning = false;
     this._touchStartEventObject = null;
+    window.addEventListener('touchstart', this._onTouchStart); // mobile
+    window.addEventListener('touchend', this._onTouchEnd); // mobile
+    window.addEventListener('touchmove', this._onScrollEvent, { passive: false }); // mobile
+    window.addEventListener('wheel', this._onScrollEvent, { passive: false });
+    document.addEventListener('wheel', this._onScrollEvent, { passive: false });
+    document.addEventListener('keydown', this._onKeyDown);
   }
 
   /**
@@ -84,12 +90,6 @@ export default class Scroll extends Backbone.Controller {
       return;
     }
     this._isRunning = true;
-    window.addEventListener('touchstart', this._onTouchStart); // mobile
-    window.addEventListener('touchend', this._onTouchEnd); // mobile
-    window.addEventListener('touchmove', this._onScrollEvent, { passive: false }); // mobile
-    window.addEventListener('wheel', this._onScrollEvent, { passive: false });
-    document.addEventListener('wheel', this._onScrollEvent, { passive: false });
-    document.addEventListener('keydown', this._onKeyDown);
   }
 
   /**
@@ -98,6 +98,7 @@ export default class Scroll extends Backbone.Controller {
    * @param {JQuery.Event} event
    */
   _onTouchStart(event) {
+    if (!this._isRunning) return;
     event = $.event.fix(event);
     this._touchStartEventObject = event;
     return true;
@@ -107,6 +108,7 @@ export default class Scroll extends Backbone.Controller {
    * Clear touchstart event object.
    */
   _onTouchEnd() {
+    if (!this._isRunning) return;
     this._touchStartEventObject = null;
     return true;
   }
@@ -117,6 +119,7 @@ export default class Scroll extends Backbone.Controller {
    * @param {JQuery.Event} event
    */
   _onScrollEvent(event) {
+    if (!this._isRunning) return;
     event = $.event.fix(event);
     return this._preventScroll(event);
   }
@@ -127,6 +130,7 @@ export default class Scroll extends Backbone.Controller {
    * @param {JQuery.Event} event
    */
   _onKeyDown(event) {
+    if (!this._isRunning) return;
     event = $.event.fix(event);
     if (!this._preventScrollOnKeys[event.which]) {
       return;
@@ -322,13 +326,6 @@ export default class Scroll extends Backbone.Controller {
       return;
     }
     this._isRunning = false;
-    window.removeEventListener('touchstart', this._onTouchStart); // mobile
-    window.removeEventListener('touchend', this._onTouchEnd); // mobile
-    // shouldn't need to supply 3rd arg when removing, but IE11 won't remove the event listener if you don't - see https://github.com/adaptlearning/adapt_framework/issues/2466
-    window.removeEventListener('touchmove', this._onScrollEvent, { passive: false }); // mobile
-    window.removeEventListener('wheel', this._onScrollEvent, { passive: false });
-    document.removeEventListener('wheel', this._onScrollEvent, { passive: false });
-    document.removeEventListener('keydown', this._onKeyDown);
   }
 
 }


### PR DESCRIPTION
fixes #367 

Tested on Chrome Android and Windows with mousewheel, touch and keyboard interactions.

### Fix
* Fixed typo in previous commit https://github.com/adaptlearning/adapt-contrib-core/commit/18391922a770faeea65564d5bcd0a3170cf77ecd
* In order to sidestep Safari 16.4 issues, DOM event attachment is permanent and returned early rather than toggled attached and removed
