### PR TITLE
New: Added xlarge breakpoint, added isScreenSizeMin

### DIFF
--- a/js/device.js
+++ b/js/device.js
@@ -52,13 +52,12 @@ class Device extends Backbone.Controller {
   }
 
   /**
-   * Compares the calculated screen width to the breakpoints defined in config.json.
-   *
-   * @returns {string} 'large', 'medium' or 'small'
+   * Returns an object of screen size names and em values
+   * @returns {Object}
    */
-  checkScreenSize() {
+  get screenSizes() {
     const screenSizes = { ...Adapt.config.get('screenSize') };
-    let screenSizesList = Object.entries(screenSizes);
+    const screenSizesList = Object.entries(screenSizes);
     const screensizeEmThreshold = 300;
     const baseFontSize = 16;
     for (const [name, value] of screenSizesList) {
@@ -69,11 +68,28 @@ class Device extends Backbone.Controller {
         ? value / baseFontSize
         : value;
     }
-    // Reread list after modifications
-    screenSizesList = Object.entries(screenSizes);
+    return screenSizes;
+  }
+
+  /**
+   * Returns a boolean if the current screen size is equal to or above the named
+   * screen size.
+   * @param {string} name
+   * @returns {boolean}
+   */
+  isScreenSizeFrom(name) {
+    return Boolean(window.matchMedia(`(min-width: ${this.screenSizes[name]}em)`)?.matches);
+  }
+
+  /**
+   * Returns the calculated screen width name.
+   * @returns {string} 'large', 'medium' or 'small'
+   */
+  checkScreenSize() {
+    const screenSizesList = Object.entries(this.screenSizes);
+    screenSizesList.sort((a, b) => a[1] - b[1]);
     const fontSize = parseFloat($('html').css('font-size'));
     const screenSizeEmWidth = (window.innerWidth / fontSize);
-    screenSizesList.sort((a, b) => a[1] - b[1]);
     const smallestScreenSize = screenSizesList[0][0];
     // Find the best sized screen size
     const screenSize = screenSizesList.reduce((screenSize, [name, value]) => {

--- a/js/device.js
+++ b/js/device.js
@@ -77,7 +77,7 @@ class Device extends Backbone.Controller {
    * @param {string} name
    * @returns {boolean}
    */
-  isScreenSizeFrom(name) {
+  isScreenSizeMin(name) {
     return Boolean(window.matchMedia(`(min-width: ${this.screenSizes[name]}em)`)?.matches);
   }
 

--- a/js/device.js
+++ b/js/device.js
@@ -170,9 +170,12 @@ class Device extends Backbone.Controller {
     const newScreenSize = this.checkScreenSize();
     if (newScreenSize !== this.screenSize) {
       this.screenSize = newScreenSize;
-      this.$html.toggleClass('size-small', this.screenSize === 'small');
-      this.$html.toggleClass('size-medium', this.screenSize === 'medium');
-      this.$html.toggleClass('size-large', this.screenSize === 'large');
+      const screenSizes = this.screenSizes;
+      for (const name in screenSizes) {
+        if (name === this.screenSize) continue;
+        this.$html.removeClass(`size-${name}`);
+      }
+      this.$html.toggleClass(`size-${this.screenSize}`, true);
       Adapt.trigger('device:changed', this.screenSize);
     }
 

--- a/js/device.js
+++ b/js/device.js
@@ -82,6 +82,16 @@ class Device extends Backbone.Controller {
   }
 
   /**
+    * Returns a boolean if the current screen size is equal to or below the named
+    * screen size.
+    * @param {string} name
+    * @returns {boolean}
+    */
+  isScreenSizeMax(name) {
+    return Boolean(window.matchMedia(`(max-width: ${this.screenSizes[name]}em)`)?.matches);
+  }
+
+  /**
    * Returns the calculated screen width name.
    * @returns {string} 'large', 'medium' or 'small'
    */

--- a/js/device.js
+++ b/js/device.js
@@ -82,16 +82,6 @@ class Device extends Backbone.Controller {
   }
 
   /**
-    * Returns a boolean if the current screen size is equal to or below the named
-    * screen size.
-    * @param {string} name
-    * @returns {boolean}
-    */
-  isScreenSizeMax(name) {
-    return Boolean(window.matchMedia(`(max-width: ${this.screenSizes[name]}em)`)?.matches);
-  }
-
-  /**
    * Returns the calculated screen width name.
    * @returns {string} 'large', 'medium' or 'small'
    */

--- a/less/_defaults/_variables.less
+++ b/less/_defaults/_variables.less
@@ -27,7 +27,7 @@
 @device-width-large: unit(@adapt-device-large, rem);
 @device-width-xlarge: unit(@adapt-device-xlarge, rem);
 
-@max-width: 80rem;
+@max-width: 90rem;
 
 @max-content-width: @device-width-large;
 @max-page-width: @max-width;

--- a/less/_defaults/_variables.less
+++ b/less/_defaults/_variables.less
@@ -16,10 +16,8 @@
 // --------------------------------------------------
 // html = 16px
 
-// 20rem = 320px
-// 32.5rem = 520px
-// 47.5rem = 760px
-// 56.25rem = 900px
+// 45rem = 720px
+// 60rem = 960px
 // 80rem = 1280px
 // 90rem = 1440px
 // 120rem = 1920px
@@ -27,8 +25,9 @@
 @device-width-small: unit(@adapt-device-small, rem);
 @device-width-medium: unit(@adapt-device-medium, rem);
 @device-width-large: unit(@adapt-device-large, rem);
+@device-width-xlarge: unit(@adapt-device-xlarge, rem);
 
-@max-width: 90rem;
+@max-width: 80rem;
 
 @max-content-width: @device-width-large;
 @max-page-width: @max-width;

--- a/schema/config.model.schema
+++ b/schema/config.model.schema
@@ -192,6 +192,15 @@
       "type": "object",
       "title": "Screen Size",
       "properties": {
+        "xsmall": {
+          "type": "number",
+          "required": true,
+          "default": 0,
+          "title": "Extra Small",
+          "inputType": "Number",
+          "validators": ["required", "number"],
+          "help": "Pixel width for the extra small breakpoint, e.g. small cellphones"
+        },
         "small": {
           "type": "number",
           "required": true,

--- a/schema/config.model.schema
+++ b/schema/config.model.schema
@@ -192,41 +192,41 @@
       "type": "object",
       "title": "Screen Size",
       "properties": {
-        "xsmall": {
-          "type": "number",
-          "required": true,
-          "default": 0,
-          "title": "Extra Small",
-          "inputType": "Number",
-          "validators": ["required", "number"],
-          "help": "Pixel width for the extra small breakpoint, e.g. small cellphones"
-        },
         "small": {
           "type": "number",
           "required": true,
-          "default": 520,
+          "default": 0,
           "title": "Small",
           "inputType": "Number",
           "validators": ["required", "number"],
-          "help": "Pixel width for the small breakpoint, e.g. cellphones"
+          "help": "Pixel width for the start of the small breakpoint, e.g. cellphones"
         },
         "medium": {
           "type": "number",
           "required": true,
-          "default": 760,
+          "default": 720,
           "title": "Medium",
           "inputType": "Number",
           "validators": ["required", "number"],
-          "help": "Pixel width for the medium breakpoint, e.g. tablet devices"
+          "help": "Pixel width for the start of the medium breakpoint, e.g. tablet devices"
         },
         "large": {
           "type": "number",
           "required": true,
-          "default": 900,
+          "default": 960,
           "title": "Large",
           "inputType": "Number",
           "validators": ["required", "number"],
-          "help": "Pixel width for the large breakpoint, e.g. laptop/desktop computers"
+          "help": "Pixel width for the start of the large breakpoint, e.g. laptop/desktop computers"
+        },
+        "xlarge": {
+          "type": "number",
+          "required": true,
+          "default": 1280,
+          "title": "Large",
+          "inputType": "Number",
+          "validators": ["required", "number"],
+          "help": "Pixel width for the start of the extra large breakpoint, e.g. hd laptop/desktop computers"
         }
       }
     },

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -176,6 +176,12 @@
       "title": "Device breakpoints",
       "default": {},
       "properties": {
+        "xsmall": {
+          "type": "number",
+          "title": "Extra Small",
+          "description": "Pixel width for the extra small breakpoint, e.g. small cellphones",
+          "default": 0
+        },
         "small": {
           "type": "number",
           "title": "Small",

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -176,29 +176,29 @@
       "title": "Device breakpoints",
       "default": {},
       "properties": {
-        "xsmall": {
-          "type": "number",
-          "title": "Extra Small",
-          "description": "Pixel width for the extra small breakpoint, e.g. small cellphones",
-          "default": 0
-        },
         "small": {
           "type": "number",
           "title": "Small",
-          "description": "Pixel width for the small breakpoint, e.g. cellphones",
-          "default": 520
+          "description": "Pixel width for the start of the small breakpoint, e.g. cellphones",
+          "default": 0
         },
         "medium": {
           "type": "number",
           "title": "Medium",
-          "description": "Pixel width for the medium breakpoint, e.g. tablet devices",
-          "default": 760
+          "description": "Pixel width for the start of the medium breakpoint, e.g. tablet devices",
+          "default": 720
         },
         "large": {
           "type": "number",
           "title": "Large",
-          "description": "Pixel width for the large breakpoint, e.g. laptop/desktop computers",
-          "default": 900
+          "description": "Pixel width for the start of the large breakpoint, e.g. laptop/desktop computers",
+          "default": 960
+        },
+        "xlarge": {
+          "type": "number",
+          "title": "Large",
+          "description": "Pixel width for the start of the extra large breakpoint, e.g. hd laptop/desktop computers",
+          "default": 1280
         }
       }
     },

--- a/templates/header.jsx
+++ b/templates/header.jsx
@@ -34,7 +34,7 @@ export default function Header(props) {
       _extension && _extension.toLowerCase()
     ].filter(Boolean)
   } = props;
-  const sizedInstruction = (mobileInstruction && device.isScreenSizeMax('small')) ?
+  const sizedInstruction = (mobileInstruction && !device.isScreenSizeMin('medium')) ?
     mobileInstruction :
     instruction;
   const _globals = Adapt.course.get('_globals');

--- a/templates/header.jsx
+++ b/templates/header.jsx
@@ -34,7 +34,7 @@ export default function Header(props) {
       _extension && _extension.toLowerCase()
     ].filter(Boolean)
   } = props;
-  const sizedInstruction = (mobileInstruction && device.screenSize !== 'large') ?
+  const sizedInstruction = (mobileInstruction && device.isScreenSizeMax('small')) ?
     mobileInstruction :
     instruction;
   const _globals = Adapt.course.get('_globals');

--- a/templates/image.jsx
+++ b/templates/image.jsx
@@ -10,10 +10,10 @@ import { html, classes, prefixClasses } from 'core/js/reactHelpers';
  * @param {Array} [props.attributionClassNamePrefixes]
  */
 export default function Image(props) {
-  const hasMediumSetting = (Object.prototype.hasOwnProperty.call(props, '_medium') || Object.prototype.hasOwnProperty.call(props, 'medium'));
-  const screenSize = hasMediumSetting
+  const hasMatchingSetting = (Object.prototype.hasOwnProperty.call(props, `_${device.screenSize}`) || Object.prototype.hasOwnProperty.call(props, device.screenSize));
+  const screenSize = hasMatchingSetting
     ? device.screenSize
-    : (device.screenSize === 'large' ? 'large' : 'small');
+    : (device.isScreenSizeMin('medium') ? 'large' : 'small');
   const src = (
     props[`_${screenSize}`] ||
     props[`${screenSize}`] ||

--- a/templates/image.jsx
+++ b/templates/image.jsx
@@ -10,7 +10,7 @@ import { html, classes, prefixClasses } from 'core/js/reactHelpers';
  * @param {Array} [props.attributionClassNamePrefixes]
  */
 export default function Image(props) {
-  const hasMatchingSetting = (Object.prototype.hasOwnProperty.call(props, `_${device.screenSize}`) || Object.prototype.hasOwnProperty.call(props, device.screenSize));
+  const hasMatchingSetting = (Object.hasOwn(props, `_${device.screenSize}`) || Object.hasOwn(props, device.screenSize));
   const screenSize = hasMatchingSetting
     ? device.screenSize
     : (device.isScreenSizeMin('medium') ? 'large' : 'small');


### PR DESCRIPTION
fixes #371 

Alternative to https://github.com/adaptlearning/adapt-contrib-core/pull/373

### New
* Add `xlarge` default to schemas starting at 1280
* Add `device.isScreenSizeMin(name)` to return true/false if the device is equal or above the named screen size

### Fix
* Adjusted the breakpoints and schema descriptions so that it's clear that the breakpoint values are for the bottom of each named boundary according to https://github.com/adaptlearning/adapt-contrib-core/issues/364#issuecomment-1544268315
* Recalculated `size-` classes were not derivable
* `mobileInstruction` now only appears at `small`, to account for the `small` > `medium` change in hotgraphic and narrative
* When **only** `small` and `large` images are defined, images  switch from `small` to `large` at `medium` or above to better fit the change from 1 component to 2 component layouts

### Breakpoints
All breakpoints are multiples of 8.

| Name | Value | Range | Distance | Components | Columns | Deviceish |
|--------|-------|---------|--|-----|----|----|
| small | 0 | 0- 719 | 720 | 1 | 4 | mobile portrait |
| medium | 720 | 720 - 959 | 240 | 2 | 8 | portait tablet, landscape mobile |
| large | 960 | 960 -  1279 | 480 | 2 | 12 | large portrait tablet, landscape tablet, small desktop, laptop, netbook |
| xlarge | 1280 | 1280+ | n/a | 2 | 12 | desktop, laptop, etc |

* `small` is for single component views
* `medium` and above are for double component views
* `xlarge` is at 1280 to match up with [Google M1 breakpoints](https://m1.material.io/layout/responsive-ui.html#responsive-ui-breakpoints)
* `@max-page-width` at 1440, for limiting the maximum container widths
* Edge cases for ultra small devices can be specifically created in a theme

Rationale from https://github.com/adaptlearning/adapt-contrib-core/issues/364

#### Testing
Use:
* https://github.com/adaptlearning/adapt-contrib-narrative/pull/264
* https://github.com/adaptlearning/adapt-contrib-hotgraphic/pull/269
* https://github.com/adaptlearning/adapt-contrib-gmcq/pull/169