### PR TITLE
Fix: reactHelpers.helper pass through correct this context

### DIFF
--- a/js/reactHelpers.js
+++ b/js/reactHelpers.js
@@ -88,7 +88,7 @@ export function partial(name, ...args) {
  * @param {...any} args Helper arguments
  */
 export function helper(name, ...args) {
-  const output = Handlebars.helpers[name].call(this, args[0]);
+  const output = Handlebars.helpers[name].call(this ?? args[0], args[0]);
   return (output && output.string) || output;
 };
 


### PR DESCRIPTION
fixes #374 

### Fix
* reactHelpers.helper passes through correct this context for handlebars helpers

