### PR TITLE
Fix: Hide close button on a11y-push notify

### DIFF
--- a/js/collections/notifyPushCollection.js
+++ b/js/collections/notifyPushCollection.js
@@ -28,7 +28,7 @@ export default class NotifyPushCollection extends Backbone.Collection {
 
   showPush(model) {
     new NotifyPushView({
-      model: model
+      model
     });
   }
 

--- a/js/views/notifyView.js
+++ b/js/views/notifyView.js
@@ -50,6 +50,8 @@ export default class NotifyView extends Backbone.View {
       _closeOnShadowClick: true
     });
 
+    if (notifyObject._type === 'a11y-push') notifyObject._showCloseButton = false;
+
     switch (notifyObject._type) {
       case 'a11y-push':
       case 'push':

--- a/templates/notifyPush.hbs
+++ b/templates/notifyPush.hbs
@@ -21,6 +21,8 @@
 
 </div>
 
+{{#if _showCloseButton}}
 <button class="btn-icon notify-push__close-btn js-notify-push-close-btn" aria-label="{{_globals._accessibility._ariaLabels.closePopup}}">
   <span class="icon" aria-hidden="true"></span>
 </button>
+{{/if}}


### PR DESCRIPTION
fixes #376 

### Fix
* Hide close button on a11y-push notify
* Support `_showCloseButton` on push notifications


