### PR TITLE
Fix: Blank instruction default removed from content.schema (fixes #382)

### DIFF
--- a/schema/content.schema.json
+++ b/schema/content.schema.json
@@ -55,7 +55,6 @@
     "instruction": {
       "type": "string",
       "title": "Instruction",
-      "default": "",
       "_adapt": {
         "translatable": true
       }


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
https://github.com/adapt-security/adapt-authoring-ui/issues/245
#382 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Blank instruction default removed from content.schema (fixes #382)


