### PR TITLE
Fix: Don't rerender on removed views

### DIFF
--- a/js/views/adaptView.js
+++ b/js/views/adaptView.js
@@ -91,6 +91,7 @@ class AdaptView extends Backbone.View {
       // Ignore bubbling events as they are outside of this view's scope
       return;
     }
+    if (!this.model.get('_isRendered')) return;
     const props = {
       // Add view own properties, bound functions etc
       ...this,


### PR DESCRIPTION
fixes #387 

### Fix
* Don't rerender on removed views if properties change


