### PR TITLE
New: Added new _srcFocalPoint class to image.jsx (fixes #396)

### DIFF
--- a/templates/image.jsx
+++ b/templates/image.jsx
@@ -34,7 +34,10 @@ export default function Image(props) {
     >
 
       <img
-        className={prefixClasses(props.classNamePrefixes, ['__image'])}
+        className={classes([
+          prefixClasses(props.classNamePrefixes, ['__image']),
+          props?._srcFocalPoint && `object-position-${props?._srcFocalPoint}`
+        ])}
         src={src}
         aria-label={a11y.normalize(props.alt)}
         aria-hidden={!props.alt}


### PR DESCRIPTION
Resolves: #396 

### New
* Added a new class to image template, to be based on `_srcFocalPoint` value that's part of the `_graphic` object
