### PR TITLE
Fix: Add draggable attribute option (fixes #402)

### DIFF
--- a/templates/image.jsx
+++ b/templates/image.jsx
@@ -40,7 +40,7 @@ export default function Image(props) {
         aria-hidden={!props.alt}
         loading='eager'
         aria-describedby={props.longdescription ? props.longDescriptionId : undefined}
-        draggable={props.draggable || null}
+        draggable={props.draggable ?? null}
       />
 
       {props.attribution &&

--- a/templates/image.jsx
+++ b/templates/image.jsx
@@ -40,6 +40,7 @@ export default function Image(props) {
         aria-hidden={!props.alt}
         loading='eager'
         aria-describedby={props.longdescription ? props.longDescriptionId : undefined}
+        draggable={props.draggable || null}
       />
 
       {props.attribution &&


### PR DESCRIPTION
Fixes #402

### Fix
* Adds option for the HTML attribute `draggable`

### Testing
1. Where the image.jsx template is used, add the draggable property. For example:

```
<templates.image {..._graphic}
  draggable="false"
/>
```
2. If `draggable` is set, it should include the property on the `<img>` tag.
3. If `draggable` is not set, it should _not_ include the property on the `<img>` tag.

This will be used in https://github.com/adaptlearning/adapt-contrib-narrative/pull/270, so it can also be tested there.