### PR TITLE
Fix: Create focusAfterReset to move focus behavior from onResetClicked (fix #391)

### DIFF
--- a/js/views/questionView.js
+++ b/js/views/questionView.js
@@ -311,7 +311,7 @@ class QuestionView extends ComponentView {
 
   focusAfterReset() {
     // Focus on the first readable item in this element
-    a11y.focusNext(this.$el, { preventScroll: true });
+    a11y.focusNext(this.$el);
   }
 
   /**

--- a/js/views/questionView.js
+++ b/js/views/questionView.js
@@ -300,14 +300,18 @@ class QuestionView extends ComponentView {
     const currentModel = data.findById(location._currentId);
     // Make sure the page is ready
     if (!currentModel?.get('_isReady')) return;
-    // Focus on the first readable item in this element
-    a11y.focusNext(this.$el, { preventScroll: true });
+    this.focusAfterReset();
   }
 
   setQuestionAsReset() {
     this.model.setQuestionAsReset();
     this.resetQuestion();
     this.$('.component__widget').removeClass('is-submitted');
+  }
+
+  focusAfterReset() {
+    // Focus on the first readable item in this element
+    a11y.focusNext(this.$el, { preventScroll: true });
   }
 
   /**


### PR DESCRIPTION
Fixes #391 

### Fix
* Create `focusAfterReset()` which moves the focus behavior from `onResetClicked()`. This makes it simpler to override the focus behavior in a plugin.