### PR TITLE
Fix: Missing is-full-width class

### DIFF
--- a/js/views/buttonsView.js
+++ b/js/views/buttonsView.js
@@ -136,7 +136,7 @@ export default class ButtonsView extends Backbone.View {
 
     this.$('.js-btn-action, .js-btn-marking').toggleClass('is-full-width', !canShowFeedback);
     this.$('.js-btn-feedback').toggleClass('u-display-none', !canShowFeedback);
-    this.$('.js-btn-marking-label, .js-btn-marking').toggleClass('u-display-none', !canShowMarking);
+    this.$('.js-btn-marking, .js-btn-marking-label').toggleClass('u-display-none', !canShowMarking);
   }
 
   updateAttemptsCount() {

--- a/js/views/buttonsView.js
+++ b/js/views/buttonsView.js
@@ -134,9 +134,9 @@ export default class ButtonsView extends Backbone.View {
     const canShowFeedback = this.model.get('_canShowFeedback');
     const canShowMarking = this.model.get('_canShowMarking');
 
-    this.$('.js-btn-action').toggleClass('is-full-width', !canShowFeedback);
+    this.$('.js-btn-action, .js-btn-marking').toggleClass('is-full-width', !canShowFeedback);
     this.$('.js-btn-feedback').toggleClass('u-display-none', !canShowFeedback);
-    this.$('.js-btn-marking, .js-btn-marking-label').toggleClass('is-full-width u-display-none', !canShowMarking);
+    this.$('.js-btn-marking-label, .js-btn-marking').toggleClass('u-display-none', !canShowMarking);
   }
 
   updateAttemptsCount() {


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-core/issues/390

### Fix
* The class `is-full-width` was not being applied to the `js-btn-marking` icon when it should have, meaning that it was appearing in the center, when it should have been to the right of the full width button.

![image](https://github.com/adaptlearning/adapt-contrib-core/assets/1676635/d655567c-d875-4f15-b5e3-2afbd5cd667e)


### Testing
1. In any question component set `_canShowMarking` to true and `_canShowFeedback` to False.
2. Complete the question and confirm that the icon is on the right
3. Keep testing with other configurations of these settings to confirm that they all work correctly.


