### PR TITLE
Fix: remove component diplayTitle and Title fallbacks for feedbackTitle

### DIFF
--- a/js/models/questionModel.js
+++ b/js/models/questionModel.js
@@ -286,10 +286,6 @@ class QuestionModel extends ComponentModel {
         Adapt.course.get('_globals')._accessibility.altFeedbackTitle ||
         '',
       title: feedback.title ||
-        feedback.altTitle ||
-        Adapt.course.get('_globals')._accessibility.altFeedbackTitle ||
-        this.get('displayTitle') ||
-        this.get('title') ||
         '',
       _classes: feedback._classes,
       ...(isLegacyConfig

--- a/js/models/questionModel.js
+++ b/js/models/questionModel.js
@@ -286,6 +286,8 @@ class QuestionModel extends ComponentModel {
         Adapt.course.get('_globals')._accessibility.altFeedbackTitle ||
         '',
       title: feedback.title ||
+        feedback.altTitle ||
+        Adapt.course.get('_globals')._accessibility.altFeedbackTitle ||
         this.get('displayTitle') ||
         this.get('title') ||
         '',


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Currently if no feedback title is given the questionModel will return the components display title/title meaning that the altTitle isn't used unless all of the feedback/component titles are empty. 

My suggestion is to remove the components display title/title as fallbacks so if no feedback title is given the altTitle is used for screen readers with no visible feedback title. 

Original issue - #411 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* remove component diplayTitle and Title fallbacks for feedbackTitle (fixes #411 )


