### PR TITLE
Fix: focusFirst on document.body when navigating to a contentObject (#431)

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -366,6 +366,10 @@ class Router extends Backbone.Router {
             resolve();
           }, 1)));
           this.isScrolling = false;
+          if (currentModel.isTypeGroup('contentobject')) {
+            a11y.focusFirst(document.body);
+            return;
+          }
         }
         await Adapt.parentView.renderTo(currentModelId);
       }


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
#431 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* focusFirst on document.body when navigating to a contentObject (fixes #431)

