### PR TITLE
New: Add html classes depending on the loading screen's visibility (fixes #423)

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -41,10 +41,12 @@ class Router extends Backbone.Router {
   }
 
   showLoading() {
+    $('html').removeClass('is-loading-hidden').addClass('is-loading-visible');
     $('.js-loading').show();
   }
 
   hideLoading() {
+    $('html').addClass('is-loading-hidden').removeClass('is-loading-visible');
     $('.js-loading').hide();
   }
 

--- a/js/views/contentObjectView.js
+++ b/js/views/contentObjectView.js
@@ -3,6 +3,7 @@ import wait from 'core/js/wait';
 import AdaptView from 'core/js/views/adaptView';
 import ReactDOM from 'react-dom';
 import data from 'core/js/data';
+import router from 'core/js/router';
 
 export default class ContentObjectView extends AdaptView {
 
@@ -68,7 +69,7 @@ export default class ContentObjectView extends AdaptView {
     const performIsReady = async () => {
       Adapt.trigger(`${type}View:preReady contentObjectView:preReady view:preReady`, this);
       await wait.queue();
-      $('.js-loading').hide();
+      router.hideLoading();
       if (Adapt.get('_shouldContentObjectScrollTop') !== false) {
         $(window).scrollTop(0);
       }


### PR DESCRIPTION
Fixes #423 

### Fix
* TBD

### Testing
1. Steps for testing

### Related
Language Picker and Spoor should be updated to use `router.hideLoading()` instead of the current `$('.js-loading').hide()`.


