### PR TITLE
Fix: ENUM refactor, linting and fix aliases (fixes #436)

### DIFF
--- a/libraries/enum.js
+++ b/libraries/enum.js
@@ -1,7 +1,7 @@
 // 2023-08-31 BASIC ENUMERATION SUPPORT
 (function() {
   function ENUM(namesArray, lookupModifierFunction) {
-    if (!(namesArray instanceof Array)) throw new Error('First argument of ENUM must be an array');
+    if (!Array.isArray(namesArray)) throw new Error('First argument of ENUM must be an array');
     const lookupHash = {};
     // Create lookup & storage function
     const ENUMERATION = function (lookupValue) {

--- a/libraries/enum.js
+++ b/libraries/enum.js
@@ -18,7 +18,9 @@
       // Make each value a power of 2 to allow for bitwise switches
       const value = Math.pow(2, i);
       const baseName = names[0];
+      // Add values to lookup hash
       lookupHash[baseName] = baseName;
+      lookupHash[value] = baseName;
       // Create Number object to allow for primitive comparisons, JSON stringify and sub properties
       // eslint-disable-next-line no-new-wrappers
       const entry = new Number(value);
@@ -36,8 +38,7 @@
           enumerable: (n === 0),
           value: entry
         });
-        // Add value to lookup hash
-        lookupHash[value] = baseName;
+        lookupHash[name] = baseName;
       });
     });
     // Freeze ENUM object

--- a/libraries/enum.js
+++ b/libraries/enum.js
@@ -1,78 +1,48 @@
-//2017-03-06 BASIC ENUMERATION SUPPORT https://github.com/cgkineo/enum
+// 2023-08-31 BASIC ENUMERATION SUPPORT
 (function() {
-
   function ENUM(namesArray, lookupModifierFunction) {
-
-    if (!(namesArray instanceof Array)) throw "First argument of ENUM must be an array";
-
-    var lookupHash = {};
-
+    if (!(namesArray instanceof Array)) throw new Error('First argument of ENUM must be an array');
+    const lookupHash = {};
     // Create lookup & storage function
-    var ENUMERATION = function(lookupValue){
-
-      if (lookupModifierFunction) {
-        lookupValue = lookupModifierFunction(lookupValue);
-      }
-
+    const ENUMERATION = function (lookupValue) {
+      if (lookupModifierFunction) lookupValue = lookupModifierFunction(lookupValue);
       lookupValue = lookupHash[lookupValue];
-
       return ENUMERATION[lookupValue];
-
     };
-
-    for (var i = 0, l = namesArray.length; i < l; i++) {
-
-      var names = namesArray[i];
-      if (!(names instanceof Array)) names = [names];
-
+    Object.defineProperty(ENUMERATION, 'lookupHash', {
+      enumerable: false,
+      value: lookupHash
+    });
+    namesArray.forEach((names, i) => {
+      if (!Array.isArray(names)) names = [names];
       // Make each value a power of 2 to allow for bitwise switches
-      var value = Math.pow(2, i);
-      var baseName = names[0];
+      const value = Math.pow(2, i);
+      const baseName = names[0];
       lookupHash[baseName] = baseName;
-
-      for (var n = 0, m = names.length; n < m; n++) {
-
-        var name = names[n];
-
-        // Create Number object to allow for primitive comparisons and JSON stringify
-        var entry = new Number(value);
-
-        // Assign conversion values to entry
-        entry.asString = name;
-        entry.asLowerCase = name.toLowerCase();
-        entry.asUpperCase = name.toUpperCase();
-        entry.asInteger = value;
-
-        // Reference lookup & storage function from each entry
-        entry.ENUM = ENUMERATION;
-
-        // Add entry to lookup & storage function
-        if (n == 0) {
-
-          // Add primary name as enumerable property
-          ENUMERATION[name] = entry;
-
-          // Add value to lookup hash
-          lookupHash[value] = baseName;
-
-        } else {
-
-          // Add alias to lookup hash
-          lookupHash[name] = baseName;
-
-        }
-
-      }
-
-    }
-
+      // Create Number object to allow for primitive comparisons, JSON stringify and sub properties
+      // eslint-disable-next-line no-new-wrappers
+      const entry = new Number(value);
+      // Assign conversion values to entry
+      entry.toString = () => entry.asString;
+      entry.asString = baseName;
+      entry.asLowerCase = baseName.toLowerCase();
+      entry.asUpperCase = baseName.toUpperCase();
+      entry.asInteger = value;
+      // Reference lookup & storage function from each entry
+      entry.ENUM = ENUMERATION;
+      names.forEach((name, n) => {
+        // Add primary name as enumerable property
+        Object.defineProperty(ENUMERATION, name, {
+          enumerable: (n === 0),
+          value: entry
+        });
+        // Add value to lookup hash
+        lookupHash[value] = baseName;
+      });
+    });
     // Freeze ENUM object
     if (Object.freeze) Object.freeze(ENUMERATION);
-
     return ENUMERATION;
-
   };
-
   window.ENUM = ENUM;
-
 })();


### PR DESCRIPTION
fixes #436 

### Fix
* Refactor to ES6
* Fix alias enumeration behaviour
* Added `toString()` which is more standard than `asString`
* Exposed `lookupHash` for easy debugging
