### PR TITLE
Fix: Drawer Back button position when using an RTL language (fixes #444)

### DIFF
--- a/less/core/drawer.less
+++ b/less/core/drawer.less
@@ -48,6 +48,11 @@
 
   &__back {
     margin-right: auto;
+
+    .dir-rtl & {
+      margin-right: inherit;
+      margin-left: auto;
+    }
   }
 
   &__back .icon {


### PR DESCRIPTION
Fix #444 

### Fix
* Fixes the drawer's Back button position when using an RTL language

### Testing
See notes in #444 