### PR TITLE
New: Labels to support new feature (fixes: Issue/446)

### DIFF
--- a/schema/course.model.schema
+++ b/schema/course.model.schema
@@ -166,6 +166,17 @@
               ],
               "translatable": true
             },
+            "bookmarkingResumeText": {
+              "type": "string",
+              "title": "Resume at furthest location label",
+              "default": "Resume",
+              "inputType": "Text",
+              "required": true,
+              "validators": [
+                "required"
+              ],
+              "translatable": true
+            },
             "_ariaLabels": {
               "type": "object",
               "title": "ARIA labels",
@@ -326,6 +337,14 @@
                   "type": "string",
                   "title": "",
                   "default": "Visited",
+                  "inputType": "Text",
+                  "required": true,
+                  "translatable": true
+                },
+                "resume": {
+                  "type": "string",
+                  "title": "",
+                  "default": "Resume",
                   "inputType": "Text",
                   "required": true,
                   "translatable": true

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -134,6 +134,14 @@
                     "translatable": true
                   }
                 },
+                "bookmarkingResumeText": {
+                  "type": "string",
+                  "title": "Resume at furthest location label",
+                  "default": "Resume",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
                 "_ariaLabels": {
                   "type": "object",
                   "title": "ARIA labels",
@@ -295,6 +303,14 @@
                       "type": "string",
                       "title": "Visited",
                       "default": "Visited",
+                      "_adapt": {
+                        "translatable": true
+                      }
+                    },
+                    "resume": {
+                      "type": "string",
+                      "title": "Resume",
+                      "default": "Resume",
                       "_adapt": {
                         "translatable": true
                       }


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### New
* Solves for #446 
* Requested addition to help with new bookmarking feature: https://github.com/adaptlearning/adapt-contrib-bookmarking/pull/64
* Adds a button label & aria label to course globals to support a new button for helping to resume learners to their furthest point of progress in a linear course.

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Test this in conjunction with the bookmarking resume feature. While this is not mandatory to test the bookmarking feature, the bookmarking feature is mandatory to test this addition.

[//]: # (Mention any other dependencies)
### Dependencies
https://github.com/adaptlearning/adapt-contrib-bookmarking/pull/64

