### PR TITLE
Fix: Notify popup - Compile _graphic.attribution (fixes #450)

### DIFF
--- a/templates/notifyPopup.hbs
+++ b/templates/notifyPopup.hbs
@@ -37,7 +37,7 @@
               {{#if _graphic.attribution}}
               <div class="notify__attribution">
                 <div class="notify__attribution-inner">
-                  {{{_graphic.attribution}}}
+                  {{{compile _graphic.attribution}}}
                 </div>
               </div>
               {{/if}}
@@ -60,7 +60,7 @@
               {{#if _graphic.attribution}}
               <div class="notify__attribution">
                 <div class="notify__attribution-inner">
-                  {{{_graphic.attribution}}}
+                  {{{compile _graphic.attribution}}}
                 </div>
               </div>
               {{/if}}


### PR DESCRIPTION
Fix #450 

### Fix
* Notify popup template - Compile the `_graphic.attribution` property so that Handlebars helpers can be used in the content.

### Testing
Add a helper to the `_graphic.attribution` property in a feedback popup.

Example helper:
```
{{a11y_alt_text '$5bn' 'five billion dollars'}}
```

Example `_feedback`:
```
    "_feedback": {
      "altTitle": "",
      "title": "Feedback",
      "_classes": "",
      "_correct": {
        "altTitle": "",
        "title": "Well done!",
        "body": "",
        "_classes": "notify-graphic-with-score",
        "_imageAlignment": "right",
        "_graphic": {
          "alt": "5 billion dollars",
          "_src": "assets/5-billion.png",
          "attribution": "{{a11y_alt_text '$5bn' 'five billion dollars'}}"
        }
      },
```