### PR TITLE
Fix: Added _isPartlyCorrect to storage mechanism (fixes #457)

### DIFF
--- a/js/models/questionModel.js
+++ b/js/models/questionModel.js
@@ -34,7 +34,8 @@ class QuestionModel extends ComponentModel {
       '_isSubmitted',
       '_score',
       '_isCorrect',
-      '_attemptsLeft'
+      '_attemptsLeft',
+      '_isPartlyCorrect'
     ]);
   }
 
@@ -43,7 +44,8 @@ class QuestionModel extends ComponentModel {
       Boolean,
       Number,
       Boolean,
-      Number
+      Number,
+      Boolean
     ]);
   }
 


### PR DESCRIPTION
fixes #457 

### Fix
* Added `_isPartlyCorrect` to storage mechanism

### Test
* Answer the mcq `c-60`
* Use the console to check that `_isPartlyCorrect` was stored in the attempt object
![image](https://github.com/adaptlearning/adapt-contrib-core/assets/7974663/9f329efb-306a-4c20-b7b8-3e28c35de2be)


