### PR TITLE
Fix: Add _isA11yCompletionDescriptionEnabled to schema and remove legacy _disableAccessibilityState (fixes #246)

### DIFF
--- a/schema/article.model.schema
+++ b/schema/article.model.schema
@@ -99,6 +99,15 @@
       "validators": ["number"],
       "help": "If you need to override the default article ARIA level (as defined in Configuration Settings), set this to any number greater than 0."
     },
+    "_isA11yCompletionDescriptionEnabled": {
+      "type": "boolean",
+      "default": true,
+      "isSetting": true,
+      "inputType": "Checkbox",
+      "validators": [],
+      "title": "Enable accessibility completion description",
+      "help": "Controls whether a hidden label is appended to the article title that describes the completion state of the article."
+    },
     "_onScreen": {
       "type": "object",
       "title": "On-screen classes",

--- a/schema/block.model.schema
+++ b/schema/block.model.schema
@@ -107,6 +107,15 @@
       "validators": ["number"],
       "help": "If you need to override the default block ARIA level (as defined in Configuration Settings), set this to any number greater than 0."
     },
+    "_isA11yCompletionDescriptionEnabled": {
+      "type": "boolean",
+      "default": true,
+      "isSetting": true,
+      "inputType": "Checkbox",
+      "validators": [],
+      "title": "Enable accessibility completion description",
+      "help": "Controls whether a hidden label is appended to the block title that describes the completion state of the block."
+    },
     "_onScreen": {
       "type": "object",
       "title": "On-screen classes",

--- a/schema/component.model.schema
+++ b/schema/component.model.schema
@@ -91,14 +91,14 @@
       "validators": ["number"],
       "help": "If you need to override the default component ARIA level (as defined in Configuration Settings), set this to any number greater than 0."
     },
-    "_disableAccessibilityState": {
+    "_isA11yCompletionDescriptionEnabled": {
       "type": "boolean",
-      "default": false,
+      "default": true,
       "isSetting": true,
       "inputType": "Checkbox",
       "validators": [],
-      "title": "Is the accessibility state disabled?",
-      "help": "Controls whether the user can tab to a hidden label that describes the completion state of the component"
+      "title": "Enable accessibility completion description",
+      "help": "Controls whether a hidden label is appended to the component title that describes the completion state of the component."
     },
     "_parentId": {
       "type": "objectid",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -35,11 +35,11 @@
           },
           "_backboneForms": "Select"
         },
-        "_disableAccessibilityState": {
+        "_isA11yCompletionDescriptionEnabled": {
           "type": "boolean",
-          "title": "Disable completion ARIA label",
-          "description": "Controls whether the user can tab to a hidden label that describes the completion state of the component",
-          "default": false,
+          "title": "Enable accessibility completion description",
+          "description": "Controls whether a hidden label is appended to the component title that describes the completion state of the component.",
+          "default": true,
           "_adapt": {
             "isSetting": true
           }

--- a/schema/content.schema.json
+++ b/schema/content.schema.json
@@ -114,6 +114,15 @@
         "isSetting": true
       }
     },
+    "_isA11yCompletionDescriptionEnabled": {
+      "type": "boolean",
+      "title": "Enable accessibility completion description",
+      "description": "Controls whether a hidden label is appended to the element title that describes the completion state of the element.",
+      "default": true,
+      "_adapt": {
+        "isSetting": true
+      }
+    },
     "_onScreen": {
       "type": "object",
       "title": "Animation classes",

--- a/schema/contentobject.model.schema
+++ b/schema/contentobject.model.schema
@@ -194,6 +194,15 @@
       "validators": ["number"],
       "help": "If you need to override the default page ARIA level (as defined in Configuration Settings), set this to any number greater than 0."
     },
+    "_isA11yCompletionDescriptionEnabled": {
+      "type": "boolean",
+      "default": true,
+      "isSetting": true,
+      "inputType": "Checkbox",
+      "validators": [],
+      "title": "Enable accessibility completion description",
+      "help": "Controls whether a hidden label is appended to the menu/page title that describes the completion state of the menu/page."
+    },
     "_onScreen": {
       "type": "object",
       "title": "On-screen classes",

--- a/schema/course.model.schema
+++ b/schema/course.model.schema
@@ -75,6 +75,15 @@
       "validators": [],
       "help": "If set, this class will be applied to the <html> element when the top-level menu in the course is displayed. These are predefined in the theme or added in Custom CSS/Less code."
     },
+    "_isA11yCompletionDescriptionEnabled": {
+      "type": "boolean",
+      "default": true,
+      "isSetting": true,
+      "inputType": "Checkbox",
+      "validators": [],
+      "title": "Enable accessibility completion description",
+      "help": "Controls whether a hidden label is appended to the course title that describes the completion state of the course."
+    },
     "_extensions": {
       "type": "object"
     },

--- a/templates/header.jsx
+++ b/templates/header.jsx
@@ -13,7 +13,6 @@ import { classes, prefixClasses, compile } from 'core/js/reactHelpers';
  * @param {string} [props.mobileInstruction]
  * @param {string} [props._type]
  * @param {string} [props._component]
- * @param {string} [props._disableAccessibilityState]
  */
 export default function Header(props) {
   // Create references to un-controlled view containers


### PR DESCRIPTION
- Replace legacy [`_disableAccessibleState`](https://github.com/adaptlearning/adapt-contrib-core/issues/186#issuecomment-1193742040) with `_isA11yCompletionDescriptionEnabled` in component schemas.
- Remove reference to legacy `_disableAccessibilityState`.
- Add missing `_isA11yCompletionDescriptionEnabled` to schemas.

Fixes https://github.com/adaptlearning/adapt-contrib-core/issues/246

[Wiki](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes#component-model-attributes) updated in advance - `_isA11yCompletionDescriptionEnabled` added to the relevant models.