### PR TITLE
Update: Remove _ariaLevel override property (fixes #442)

### DIFF
--- a/schema/article.model.schema
+++ b/schema/article.model.schema
@@ -91,14 +91,6 @@
       "title": "Require completion of",
       "help": "The number of blocks within this article the learner must complete in order for this article to be set as completed. A value of -1 requires all of them to be completed."
     },
-    "_ariaLevel": {
-      "type": "number",
-      "default": 0,
-      "isSetting": true,
-      "inputType": "Number",
-      "validators": ["number"],
-      "help": "If you need to override the default article ARIA level (as defined in Configuration Settings), set this to any number greater than 0."
-    },
     "_isA11yCompletionDescriptionEnabled": {
       "type": "boolean",
       "default": true,

--- a/schema/block.model.schema
+++ b/schema/block.model.schema
@@ -99,14 +99,6 @@
       "title": "Require completion of",
       "help": "The number of components within this block the learner must complete in order for this block to be set as completed. A value of -1 requires all of them to be completed."
     },
-    "_ariaLevel": {
-      "type": "number",
-      "default": 0,
-      "isSetting": true,
-      "inputType": "Number",
-      "validators": ["number"],
-      "help": "If you need to override the default block ARIA level (as defined in Configuration Settings), set this to any number greater than 0."
-    },
     "_isA11yCompletionDescriptionEnabled": {
       "type": "boolean",
       "default": true,

--- a/schema/component.model.schema
+++ b/schema/component.model.schema
@@ -83,14 +83,6 @@
       "help": "Controls whether this component will be reset when the learner leaves the page then returns to it. The 'soft' setting will reset the component to allow the learner to attempt it again, but will not require them to do so; whereas the 'hard' setting will require them to do so. The default (false) will not cause the component to be reset.",
       "validators": []
     },
-    "_ariaLevel": {
-      "type": "number",
-      "default": 0,
-      "isSetting": true,
-      "inputType": "Number",
-      "validators": ["number"],
-      "help": "If you need to override the default component ARIA level (as defined in Configuration Settings), set this to any number greater than 0."
-    },
     "_isA11yCompletionDescriptionEnabled": {
       "type": "boolean",
       "default": true,

--- a/schema/content.schema.json
+++ b/schema/content.schema.json
@@ -105,15 +105,6 @@
         "isSetting": true
       }
     },
-    "_ariaLevel": {
-      "type": "number",
-      "title": "Custom ARIA level",
-      "description": "If you need to override the default element ARIA level (as defined in Configuration Settings), set this to any number greater than 0",
-      "default": 0,
-      "_adapt": {
-        "isSetting": true
-      }
-    },
     "_isA11yCompletionDescriptionEnabled": {
       "type": "boolean",
       "title": "Enable accessibility completion description",

--- a/schema/contentobject.model.schema
+++ b/schema/contentobject.model.schema
@@ -186,14 +186,6 @@
       "title": "Require completion of",
       "help": "The number of articles within this page the learner must complete in order for this page to be set as completed. A value of -1 requires all of them to be completed."
     },
-    "_ariaLevel": {
-      "type": "number",
-      "default": 0,
-      "isSetting": true,
-      "inputType": "Number",
-      "validators": ["number"],
-      "help": "If you need to override the default page ARIA level (as defined in Configuration Settings), set this to any number greater than 0."
-    },
     "_isA11yCompletionDescriptionEnabled": {
       "type": "boolean",
       "default": true,


### PR DESCRIPTION
`_ariaLevel` override removed from the page/article/block/component schemas. 

Since `_ariaLevels` were [automated in Core](https://github.com/adaptlearning/adapt-contrib-core/pull/146), there's no need to manually override these now.

Fixes https://github.com/adaptlearning/adapt-contrib-core/issues/442

[Wiki](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes) updated.
