### PR TITLE
Fix: Duplicate and persistent tooltip issues (fixes #429 #463)

### DIFF
--- a/js/views/TooltipItemView.js
+++ b/js/views/TooltipItemView.js
@@ -129,6 +129,11 @@ export default class TooltipItemView extends Backbone.View {
     this.remove();
   }
 
+  onClick() {
+    console.log('onClick!!!');
+    this.remove();
+  }
+
   onMouseOut() {
     this.remove();
   }

--- a/js/views/TooltipView.js
+++ b/js/views/TooltipView.js
@@ -18,7 +18,7 @@ export default class TooltipView extends Backbone.View {
   }
 
   initialize() {
-    _.bindAll(this, 'onMouseOver', 'onKeyDown', 'onMouseOut');
+    _.bindAll(this, 'onMouseOver', 'onKeyDown');
     this._tooltipData = {};
     this._tooltips = [];
     this.listenToOnce(Adapt, 'adapt:preInitialize', this.onAdaptPreInitialize);
@@ -27,14 +27,12 @@ export default class TooltipView extends Backbone.View {
 
   onAdaptPreInitialize() {
     if (this.config?._isEnabled === false) return;
-    this.onMouseOver = _.debounce(this.onMouseOver, 500);
     $(document).on('keydown', this.onKeyDown);
     $(document).on('focus', '[data-tooltip-id]', (...args) => {
       if (a11y.isForcedFocus) return;
       this.onMouseOver(...args);
     });
     $(document).on('mouseenter', '[data-tooltip-id]', this.onMouseOver);
-    $(document).on('mouseleave blur', '[data-tooltip-id]', this.onMouseOut);
   }
 
   get config() {
@@ -71,13 +69,6 @@ export default class TooltipView extends Backbone.View {
       this.show(tooltip, $mouseoverEl);
     }
     $(document).on('scroll', this.onScroll);
-  }
-
-  /**
-   * Cancel the last mouseover debounce
-   */
-  onMouseOut() {
-    this.onMouseOver.cancel();
   }
 
   render() {

--- a/js/views/TooltipView.js
+++ b/js/views/TooltipView.js
@@ -18,7 +18,7 @@ export default class TooltipView extends Backbone.View {
   }
 
   initialize() {
-    _.bindAll(this, 'onMouseOver', 'onKeyDown');
+    _.bindAll(this, 'onMouseOver', 'onKeyDown', 'onClick');
     this._tooltipData = {};
     this._tooltips = [];
     this.listenToOnce(Adapt, 'adapt:preInitialize', this.onAdaptPreInitialize);
@@ -33,6 +33,7 @@ export default class TooltipView extends Backbone.View {
       this.onMouseOver(...args);
     });
     $(document).on('mouseenter', '[data-tooltip-id]', this.onMouseOver);
+    $(document).on('click', '[data-tooltip-id]', this.onClick);
   }
 
   get config() {
@@ -47,6 +48,13 @@ export default class TooltipView extends Backbone.View {
    */
   onKeyDown(event) {
     if (event.key !== 'Escape') return;
+    this.hide();
+  }
+
+  /**
+   * Ensure tooltip is hidden when element is clicked
+   */
+  onClick() {
     this.hide();
   }
 


### PR DESCRIPTION
Fix #429 #463 

### Fix
* Fixes the issue where tooltips were being repeatedly created. Removes the unnecessary debounce on onMouseOver.
* Ensure tooltip is hidden when the element (e.g. a button) is clicked

### Testing (#429)
1. To test mouse functionality, hover over a navigation button that has tooltips enabled.
2. To test keyboard navigation, navigate to the button via keyboard.

### Expected result (#429)
The tooltip should only appear once and then disappear once the button loses focus or fires a mouseout event.

### Testing (#463)
1. Install Page Nav with this PR: https://github.com/cgkineo/adapt-pageNav/pull/49
2. Add a Page Nav component instance and enable tooltips.
3. In Safari, hover over a button (e.g. Previous or Root) and then click it.

### Expected result (#463 )
Tooltip should not persist when the new location has finished loading.