### PR TITLE
Fix: Firefox multiple tooltips (fixes #429)

### DIFF
--- a/js/views/TooltipView.js
+++ b/js/views/TooltipView.js
@@ -18,7 +18,7 @@ export default class TooltipView extends Backbone.View {
   }
 
   initialize() {
-    _.bindAll(this, 'onMouseOver', 'onKeyDown', 'onMouseOut');
+    _.bindAll(this, 'onMouseOver', 'onKeyDown', 'onMouseOut', 'onClick');
     this._tooltipData = {};
     this._tooltips = [];
     this.listenToOnce(Adapt, 'adapt:preInitialize', this.onAdaptPreInitialize);
@@ -35,6 +35,7 @@ export default class TooltipView extends Backbone.View {
     });
     $(document).on('mouseenter', '[data-tooltip-id]', this.onMouseOver);
     $(document).on('mouseleave blur', '[data-tooltip-id]', this.onMouseOut);
+    $(document).on('click', '[data-tooltip-id]', this.onClick);
   }
 
   get config() {
@@ -78,6 +79,13 @@ export default class TooltipView extends Backbone.View {
    */
   onMouseOut() {
     this.onMouseOver.cancel();
+  }
+
+  /**
+   * Ensure tooltip is hidden when element is clicked
+   */
+  onClick() {
+    this.hide();
   }
 
   render() {

--- a/js/views/TooltipView.js
+++ b/js/views/TooltipView.js
@@ -89,6 +89,7 @@ export default class TooltipView extends Backbone.View {
    * @param {jQuery} $mouseoverEl
    */
   show(tooltip, $mouseoverEl) {
+    if (this.isShowing(tooltip)) return;
     const tooltipItem = new TooltipItemView({
       model: tooltip,
       $target: $mouseoverEl,
@@ -96,6 +97,14 @@ export default class TooltipView extends Backbone.View {
     });
     this._tooltips.push(tooltipItem);
     this.$el.append(tooltipItem.$el);
+  }
+
+  /**
+   * @param {TooltipModel} tooltip
+   */
+  isShowing(tooltip) {
+    const id = tooltip.get('_id');
+    return this._tooltips.some(tooltipView => tooltipView.model?.get('_id') === id);
   }
 
   /**

--- a/js/views/navigationView.js
+++ b/js/views/navigationView.js
@@ -174,13 +174,17 @@ class NavigationView extends Backbone.View {
     // Sort items and add to dom in sorted order
     //   Make sure not to move any item with focus as it will lose focus
     const focusElement = document.activeElement;
+    const domOrder = [...$container[0].children];
     items.sort((a, b) => parseFloat($(a).attr('data-order') || 0) - parseFloat($(b).attr('data-order') || 0));
-    let indexOfFocused = items.findIndex(el => el === focusElement);
-    if (indexOfFocused === -1) indexOfFocused = Infinity;
-    const before = items.slice(0, indexOfFocused);
-    const after = items.slice(indexOfFocused + 1);
-    before.reverse().forEach(el => $container.prepend(el));
-    after.forEach(el => $container.append(el));
+    const hasOrderChanged = domOrder.some((item, index) => item !== items[index]);
+    if (hasOrderChanged) {
+      let indexOfFocused = items.findIndex(el => el === focusElement);
+      if (indexOfFocused === -1) indexOfFocused = Infinity;
+      const before = items.slice(0, indexOfFocused);
+      const after = items.slice(indexOfFocused + 1);
+      before.reverse().forEach(el => $container.prepend(el));
+      after.forEach(el => $container.append(el));
+    }
     this.observer?.takeRecords();
     this.listenForInjectedButtons();
   }


### PR DESCRIPTION
fixes #429 #463 

Tooltips functionality adds aria-labelledby to the mouseover element. In the navigation bar modifying any child element causes the navigation bar to attempt to correctly sort its children. In firefox, moving an element by reordering it causes the mouseover event to refire.  A tooltip is shown every time a mouseover event is fired.

### Fix
* Stop the navigation bar children from reordering if they do not need to
* Stop a tooltip showing if it is already showing
* Ensure a tooltip is hidden when any element is clicked



