### PR TITLE
Fix: incorrect `scrolledTo` event name (fixes #399).

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -426,7 +426,7 @@ class Router extends Backbone.Router {
     await new Promise(resolve => {
       _.delay(() => {
         a11y.focusNext(selector);
-        Adapt.trigger(`${location}:scrolledTo`, selector);
+        Adapt.trigger(`${newLocation}:scrolledTo`, selector);
         resolve();
       }, settings.duration + 300);
     });


### PR DESCRIPTION
Fixes #399.

### Fix
* Incorrect `scrolledTo` event name which was preventing this from being used by listeners.


