### PR TITLE
Fix: Detached elements are not focusable or readable (fixes #472)

### DIFF
--- a/js/a11y.js
+++ b/js/a11y.js
@@ -448,7 +448,8 @@ class A11y extends Backbone.Controller {
         style.visibility === 'hidden' ||
         item.getAttribute('aria-hidden') === 'true';
     });
-    if (isNotVisible) {
+    const isInDOM = Boolean($element.parents('body').length);
+    if (isNotVisible || !isInDOM) {
       return false;
     }
 

--- a/js/a11y.js
+++ b/js/a11y.js
@@ -441,6 +441,9 @@ class A11y extends Backbone.Controller {
       ? $element.add($element.parents())
       : $element;
 
+    const isInDOM = Boolean($element.parents('body').length);
+    if (!isInDOM) return false;
+    
     const isNotVisible = $branch.toArray().some(item => {
       const style = window.getComputedStyle(item);
       // make sure item is not explicitly invisible
@@ -448,8 +451,7 @@ class A11y extends Backbone.Controller {
         style.visibility === 'hidden' ||
         item.getAttribute('aria-hidden') === 'true';
     });
-    const isInDOM = Boolean($element.parents('body').length);
-    if (isNotVisible || !isInDOM) {
+    if (isNotVisible) {
       return false;
     }
 


### PR DESCRIPTION
fixes #472 

### Fix
* a11y.isReadable and therefore a11y.isFocusable returns false if element is not in the body tag