### PR TITLE
Update: Prevent Notify popup rendering empty .notify__section container (fixes #476)

### DIFF
--- a/templates/notifyPopup.hbs
+++ b/templates/notifyPopup.hbs
@@ -26,7 +26,8 @@
             </div>
           </div>
         {{/if}}
-        
+
+        {{#any _graphic._src body}}
         <div class="notify__section">
           <div class="notify__section-inner">
           
@@ -70,7 +71,8 @@
             
           </div>
         </div>
-
+        {{/any}}
+        
         {{#equals _type "alert"}}
         <div class="notify__btn-container">
           <button class="btn-text notify__btn notify__btn-alert js-notify-btn-alert" aria-label="{{{confirmText}}}">


### PR DESCRIPTION
Don't render `.notify__section` unless `_graphic.src` and/or `body` exists.

Fixes https://github.com/adaptlearning/adapt-contrib-core/issues/476

**Question**
Just something I noticed during this PR. Does anyone know what the `~` is used for in the [notifyPopup.hbs](https://github.com/adaptlearning/adapt-contrib-core/blob/535905f91b1dfca190179f6e6ef2909e020f0efb/templates/notifyPopup.hbs#L56) conditions? 
In core, this is the only hbs file using it.

