### PR TITLE
Update: Add global question altFeedbackTitle property to schemas (fixes #407)

### DIFF
--- a/schema/course.model.schema
+++ b/schema/course.model.schema
@@ -339,16 +339,16 @@
                   "required": true,
                   "translatable": true
                 }
-              },
-              "altFeedbackTitle": {
-                "type": "string",
-                "title": "Alternative Feedback Title",
-                "help": "Text read out by screen readers if no visual title is set for component question feedback.",
-                "default": "Feedback",
-                "inputType": "Text",
-                "required": false,
-                "translatable": true
               }
+            },
+            "altFeedbackTitle": {
+              "type": "string",
+              "title": "Alternative Feedback Title",
+              "help": "Text read out by screen readers if no visual title is set for component question feedback.",
+              "default": "Feedback",
+              "inputType": "Text",
+              "required": false,
+              "translatable": true
             }
           }
         },

--- a/schema/course.model.schema
+++ b/schema/course.model.schema
@@ -339,6 +339,15 @@
                   "required": true,
                   "translatable": true
                 }
+              },
+              "altFeedbackTitle": {
+                "type": "string",
+                "title": "Alternative Feedback Title",
+                "help": "Text read out by screen readers if no visual title is set for component question feedback.",
+                "default": "Feedback",
+                "inputType": "Text",
+                "required": false,
+                "translatable": true
               }
             }
           }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -300,6 +300,15 @@
                       }
                     }
                   }
+                },
+                "altFeedbackTitle": {
+                  "type": "string",
+                  "title": "Alternative Feedback Title",
+                  "description": "Text read out by screen readers if no visual title is set for component question feedback.",
+                  "default": "Feedback",
+                  "_adapt": {
+                    "translatable": true
+                  }
                 }
               }
             },


### PR DESCRIPTION
Add missing `_globals._accessibility.altFeedbackTitle` property to schemas. 

`altFeedbackTitle` was introduced in #223 to provide a global feedback title in the instance a component level `_feedback.title` (or `_feedback.altTitle` isn't set).

By setting a `default` value _"Feedback"_, when feedback is rendered within a popup, this ensures the popup dialog has an appropriate label (as raised in #483)

Fixes https://github.com/adaptlearning/adapt-contrib-core/issues/407

Wiki documentation outstanding.