### PR TITLE
Fix: Ensure drawer closed after possible manual router:navigate call

### DIFF
--- a/js/drawer.js
+++ b/js/drawer.js
@@ -11,14 +11,15 @@ class Drawer extends Backbone.Controller {
     this.listenTo(Adapt, {
       'adapt:start': this.onAdaptStart,
       'app:languageChanged': this.onLanguageChanged,
-      'navigation:toggleDrawer': this.toggle
+      'navigation:toggleDrawer': this.toggle,
+      'router:navigate': this.close
     });
   }
-  
+
   onAdaptStart() {
     this._drawerView = new DrawerView({ collection: DrawerCollection });
   }
-  
+
   onLanguageChanged() {
     tooltips.register({
       _id: 'drawer',


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #496 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Ensures the drawer gets closed after possible manual router:navigate call