### PR TITLE
Fix: Support level course in a11y.ariaLevel (fixes #453)

### DIFF
--- a/js/a11y.js
+++ b/js/a11y.js
@@ -189,6 +189,7 @@ class A11y extends Backbone.Controller {
     level = '1',
     override = null
   } = {}) {
+    if (level === 'course') level = 'menu';
     if (arguments.length === 2) {
       // backward compatibility
       level = arguments[0];
@@ -443,7 +444,7 @@ class A11y extends Backbone.Controller {
 
     const isInDOM = Boolean($element.parents('body').length);
     if (!isInDOM) return false;
-    
+
     const isNotVisible = $branch.toArray().some(item => {
       const style = window.getComputedStyle(item);
       // make sure item is not explicitly invisible

--- a/js/views/headingView.js
+++ b/js/views/headingView.js
@@ -15,7 +15,6 @@ class HeadingView extends Backbone.View {
     const isBackwardCompatible = [...this.$el[0].classList].every(name => !name.includes('-inner'));
     data._isBackwardCompatible = isBackwardCompatible;
     if (customHeadingType) data._type = customHeadingType;
-    if (data._type === 'course') data._type = 'menu';
     this.$el.html(template(data));
     this.checkCompletion();
   }


### PR DESCRIPTION
fixes #453 

### Fix
* Moved course to menu conversion back in the execution hierarchy to allow [a11y.ariaLevel](https://github.com/adaptlearning/adapt-contrib-core/blob/8b36e3ee68941b62e711198f49fa9345c1758132/js/a11y.js#L187) to convert course type to menu instead of relying on [headingView](https://github.com/adaptlearning/adapt-contrib-core/blob/8b36e3ee68941b62e711198f49fa9345c1758132/js/views/headingView.js#L18) to do it.
