### PR TITLE
Fix: Ignore .nav__skip-btn when hiding nav button labels (fixes #443)

### DIFF
--- a/less/core/nav.less
+++ b/less/core/nav.less
@@ -38,7 +38,7 @@ html.is-nav-bottom #wrapper {
     float: none !important;
   }
 
-  &.hide-label &__btn-label,
+  &.hide-label &__btn:not(.nav__skip-btn) &__btn-label,
   &__btn.hide-label &__btn-label {
     display: none;
   }


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
#443 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Ignore .nav__skip-btn when hiding nav button labels (fixes #443)
