### PR TITLE
Fix: deprecated.js src/core to core/js (fixes #513)

### DIFF
--- a/js/deprecated.js
+++ b/js/deprecated.js
@@ -178,7 +178,7 @@ Object.defineProperties(Adapt, {
   },
   offlineStorage: {
     get() {
-      logging.deprecated('offlineStorage, please use src/core/offlineStorage instead');
+      logging.deprecated('offlineStorage, please use core/js/offlineStorage instead');
       return offlineStorage;
     }
   },
@@ -232,7 +232,7 @@ Object.defineProperties(Adapt, {
   },
   wait: {
     get() {
-      logging.deprecated('Adapt.wait, please use src/core/wait instead');
+      logging.deprecated('Adapt.wait, please use core/js/wait instead');
       return wait;
     }
   }

--- a/js/scrolling.js
+++ b/js/scrolling.js
@@ -64,7 +64,7 @@ class Scrolling extends Backbone.Controller {
   _windowScrollFix() {
     /** @type {HTMLDivElement} */
     const body = document.body;
-    const html = Adapt.scrolling.$html[0];
+    const html = scrolling.$html[0];
     const scrollY = {
       get: () => body.scrollTop,
       set: value => (body.scrollTop = value)


### PR DESCRIPTION
fixes #513

### Fix
* Changed error from `src/core/offlineStorage` and `src/core/wait` to `core/js/offlineStorage` and `core/js/wait`
* Changed scrolling to refer to the singleton directly rather than through Adapt.scrolling