### PR TITLE
New: Added view remove events, attached HeadingView

### DIFF
--- a/js/headings.js
+++ b/js/headings.js
@@ -9,7 +9,11 @@ class Headings extends Backbone.Controller {
 
   onViewRender(view) {
     const $headingSeats = view.$('.js-heading');
-    $headingSeats.each((index, el) => new HeadingView({ el, model: view.model }));
+    $headingSeats.each((index, el) => new HeadingView({
+      el,
+      model: view.model,
+      parentView: view
+    }));
   }
 
 }

--- a/js/views/adaptView.js
+++ b/js/views/adaptView.js
@@ -346,12 +346,14 @@ class AdaptView extends Backbone.View {
   preRemove() {
     const type = this.constructor.type;
     Adapt.trigger(`${type}View:preRemove view:preRemove`, this);
+    this.trigger('preRemove');
   }
 
   remove() {
     const type = this.constructor.type;
     this.preRemove();
     Adapt.trigger(`${type}View:remove view:remove`, this);
+    this.trigger('remove');
     this._isRemoved = true;
     this.stopListening();
 
@@ -363,6 +365,7 @@ class AdaptView extends Backbone.View {
       super.remove();
       _.defer(() => {
         Adapt.trigger(`${type}View:postRemove view:postRemove`, this);
+        this.trigger('postRemove');
       });
       end();
     });

--- a/js/views/headingView.js
+++ b/js/views/headingView.js
@@ -2,7 +2,10 @@ import Adapt from 'core/js/adapt';
 
 class HeadingView extends Backbone.View {
 
-  initialize() {
+  initialize({
+    parentView
+  }) {
+    this.listenTo(parentView, 'preRemove', this.remove);
     this.listenTo(Adapt.parentView, 'postRemove', this.remove);
     this.listenTo(this.model, 'change:_isComplete', this.updateAria);
     this.render();


### PR DESCRIPTION
fixes #516 

### New
* Added view remove events, `preRemove`, `remove` and `postRemove`

### Fix
* HeadingView is destroyed when parent view is destroyed
