### PR TITLE
Fix: enforcing type boolean on _isActive (Fixes #523)

### DIFF
--- a/js/models/itemModel.js
+++ b/js/models/itemModel.js
@@ -15,11 +15,11 @@ export default class ItemModel extends LockingModel {
   }
 
   toggleActive(isActive = !this.get('_isActive')) {
-    this.set('_isActive', isActive);
+    this.set('_isActive', Boolean(isActive));
   }
 
   toggleVisited(isVisited = !this.get('_isVisited')) {
-    this.set('_isVisited', isVisited);
+    this.set('_isVisited', Boolean(isVisited));
   }
 
 }

--- a/js/models/itemModel.js
+++ b/js/models/itemModel.js
@@ -15,7 +15,7 @@ export default class ItemModel extends LockingModel {
   }
 
   toggleActive(isActive = !this.get('_isActive')) {
-    this.set('_isActive', Boolean(isActive));
+    this.set('_isActive', isActive);
   }
 
   toggleVisited(isVisited = !this.get('_isVisited')) {

--- a/js/models/itemModel.js
+++ b/js/models/itemModel.js
@@ -15,7 +15,7 @@ export default class ItemModel extends LockingModel {
   }
 
   toggleActive(isActive = !this.get('_isActive')) {
-    this.set('_isActive', isActive);
+    this.set('_isActive', !!isActive);
   }
 
   toggleVisited(isVisited = !this.get('_isVisited')) {

--- a/js/models/itemModel.js
+++ b/js/models/itemModel.js
@@ -15,7 +15,7 @@ export default class ItemModel extends LockingModel {
   }
 
   toggleActive(isActive = !this.get('_isActive')) {
-    this.set('_isActive', !!isActive);
+    this.set('_isActive', Boolean(isActive));
   }
 
   toggleVisited(isVisited = !this.get('_isVisited')) {

--- a/js/models/itemsQuestionModel.js
+++ b/js/models/itemsQuestionModel.js
@@ -44,7 +44,7 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
     const userAnswer = this.get('_userAnswer');
     if (!userAnswer) return;
     itemModels.each(item => {
-      Boolean(item.toggleActive(userAnswer[item.get('_index')]));
+      item.toggleActive(Boolean(userAnswer[item.get('_index')]));
     });
 
     this.setQuestionAsSubmitted();

--- a/js/models/itemsQuestionModel.js
+++ b/js/models/itemsQuestionModel.js
@@ -44,7 +44,7 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
     const userAnswer = this.get('_userAnswer');
     if (!userAnswer) return;
     itemModels.each(item => {
-      item.toggleActive(userAnswer[item.get('_index')]);
+      Boolean(item.toggleActive(userAnswer[item.get('_index')]));
     });
 
     this.setQuestionAsSubmitted();


### PR DESCRIPTION
_isActive property always expected to be boolean but toggleActive not strictly enforcing this currently

[//]: # (Link the PR to the original issue)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
enforcing type boolean on _isActive within toggleActive function


