### PR TITLE
Fix: Add default values for Drawer button icon and position (fixes #534)

### DIFF
--- a/templates/nav.hbs
+++ b/templates/nav.hbs
@@ -21,7 +21,7 @@
   {{/each}}
 
   <button name="drawer" class="btn-icon nav__btn nav__drawer-btn js-nav-drawer-btn is-position-{{#if _config._drawer._position}}{{_config._drawer._position}}{{/if}}{{#unless _config._drawer._position}}auto{{/unless}}" data-event="toggleDrawer" aria-expanded="false" aria-label="{{_globals._accessibility._ariaLabels.navigationDrawer}}" data-order="{{_globals._extensions._drawer._navOrder}}" data-tooltip-id="drawer">
-    <span class="icon {{#if _config._drawer._iconClass}}{{_config._drawer._iconClass}}{{/if}}{{#unless _config._drawer._iconClass}}icon-list{{/unless}}" aria-hidden="true"></span>
+    <span class="icon {{#if _config._drawer._iconClass}}{{_config._drawer._iconClass}}{{else}}icon-list{{/if}}" aria-hidden="true"></span>
     {{#if Adapt.course._navigation._showLabel}}
     <span class='nav__btn-label' aria-hidden="true">{{_globals._accessibility._ariaLabels.navigationDrawer}}</span>
     {{/if}}

--- a/templates/nav.hbs
+++ b/templates/nav.hbs
@@ -20,7 +20,7 @@
     <div class="nav__spacer" aria-hidden="true" data-order="{{_navOrder}}"></div>
   {{/each}}
 
-  <button name="drawer" class="btn-icon nav__btn nav__drawer-btn js-nav-drawer-btn is-position-{{#if _config._drawer._position}}{{_config._drawer._position}}{{/if}}{{#unless _config._drawer._position}}auto{{/unless}}" data-event="toggleDrawer" aria-expanded="false" aria-label="{{_globals._accessibility._ariaLabels.navigationDrawer}}" data-order="{{_globals._extensions._drawer._navOrder}}" data-tooltip-id="drawer">
+  <button name="drawer" class="btn-icon nav__btn nav__drawer-btn js-nav-drawer-btn is-position-{{#if _config._drawer._position}}{{_config._drawer._position}}{{else}}auto{{/if}}" data-event="toggleDrawer" aria-expanded="false" aria-label="{{_globals._accessibility._ariaLabels.navigationDrawer}}" data-order="{{_globals._extensions._drawer._navOrder}}" data-tooltip-id="drawer">
     <span class="icon {{#if _config._drawer._iconClass}}{{_config._drawer._iconClass}}{{else}}icon-list{{/if}}" aria-hidden="true"></span>
     {{#if Adapt.course._navigation._showLabel}}
     <span class='nav__btn-label' aria-hidden="true">{{_globals._accessibility._ariaLabels.navigationDrawer}}</span>

--- a/templates/nav.hbs
+++ b/templates/nav.hbs
@@ -21,9 +21,7 @@
   {{/each}}
 
   <button name="drawer" class="btn-icon nav__btn nav__drawer-btn js-nav-drawer-btn is-position-{{_config._drawer._position}}" data-event="toggleDrawer" aria-expanded="false" aria-label="{{_globals._accessibility._ariaLabels.navigationDrawer}}" data-order="{{_globals._extensions._drawer._navOrder}}" data-tooltip-id="drawer">
-    {{#if _config._drawer._iconClass}}
-    <span class="icon {{_config._drawer._iconClass}}" aria-hidden="true"></span>
-    {{/if}}
+    <span class="icon {{#if _config._drawer._iconClass}}{{_config._drawer._iconClass}}{{/if}}{{#unless _config._drawer._iconClass}}icon-list{{/unless}}" aria-hidden="true"></span>
     {{#if Adapt.course._navigation._showLabel}}
     <span class='nav__btn-label' aria-hidden="true">{{_globals._accessibility._ariaLabels.navigationDrawer}}</span>
     {{/if}}

--- a/templates/nav.hbs
+++ b/templates/nav.hbs
@@ -20,7 +20,7 @@
     <div class="nav__spacer" aria-hidden="true" data-order="{{_navOrder}}"></div>
   {{/each}}
 
-  <button name="drawer" class="btn-icon nav__btn nav__drawer-btn js-nav-drawer-btn is-position-{{_config._drawer._position}}" data-event="toggleDrawer" aria-expanded="false" aria-label="{{_globals._accessibility._ariaLabels.navigationDrawer}}" data-order="{{_globals._extensions._drawer._navOrder}}" data-tooltip-id="drawer">
+  <button name="drawer" class="btn-icon nav__btn nav__drawer-btn js-nav-drawer-btn is-position-{{#if _config._drawer._position}}{{_config._drawer._position}}{{/if}}{{#unless _config._drawer._position}}auto{{/unless}}" data-event="toggleDrawer" aria-expanded="false" aria-label="{{_globals._accessibility._ariaLabels.navigationDrawer}}" data-order="{{_globals._extensions._drawer._navOrder}}" data-tooltip-id="drawer">
     <span class="icon {{#if _config._drawer._iconClass}}{{_config._drawer._iconClass}}{{/if}}{{#unless _config._drawer._iconClass}}icon-list{{/unless}}" aria-hidden="true"></span>
     {{#if Adapt.course._navigation._showLabel}}
     <span class='nav__btn-label' aria-hidden="true">{{_globals._accessibility._ariaLabels.navigationDrawer}}</span>


### PR DESCRIPTION
Fixes #534 

**Note:** This PR is considered a stopgap until #512 is completed.

### Fix
Sets defaults for the Drawer navigation button:
* Set a default [icon](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Icons#icons-in-adapt) of `icon-list` for the `_iconClass` property. The icon will no longer be hidden if `_iconClass` is not set.
* Set a default `_position` of `auto`

### Testing
In _config.json_, configure the `_drawer` object with _and_ without values for `_iconClass` and `_position`. When not set, it should show the list icon and the position should be `auto`.

<img width="59" alt="list-icon" src="https://github.com/adaptlearning/adapt-contrib-core/assets/898168/377f7562-e7e6-4a1b-8c7c-90d82c3f5302">

```
  "_drawer": {
    "_showEasing": "easeOutQuart",
    "_hideEasing": "easeInQuart",
    "_duration": 400,
    "_position": "right",
    "_iconClass": "icon-folder"
  },
```


