### PR TITLE
New: event handler for CSS transitions

### DIFF
--- a/js/transitions.js
+++ b/js/transitions.js
@@ -1,6 +1,8 @@
+import logging from 'core/js/logging';
+
 /**
- * Handler to await completion of `CSSTransitions` to be run at point of execution.
- * An optional `transition-property` to await can be specified, else all properties will be included.
+ * Handler to await completion of active `CSSTransitions`.
+ * An optional `transition-property` to await can be specified, else all properties will be evaluated.
  * @param {jQuery} $element
  * @param {String} property
  * @returns {Promise}
@@ -8,69 +10,112 @@
 export async function transitionsEnded($element, property = null) {
   return new Promise(resolve => {
     if (!($element instanceof $)) $element = $($element);
-    // only listen to transitions running after execution
-    const onRun = () => $element.on('transitioncancel transitionend', onEnd);
+    const onRun = () => clearTimeout(resolveInterval);
     const onEnd = () => {
       if (!hasActiveTransition($element, property)) done(true);
     };
     const done = (didTransition) => {
+      clearTimeout(resolveInterval);
       $element
         .off('transitionrun', onRun)
         .off('transitioncancel transitionend', onEnd);
       resolve(didTransition);
     };
+    if (!willTransition($element, property)) return resolve(false);
     $element.on('transitionrun', onRun);
-    if (!willTransition($element, property)) done(false);
+    $element.on('transitioncancel transitionend', onEnd);
+    const resolveInterval = setTimeout(() => {
+      const element = $element[0];
+      const id = element.name || element.id || element.className;
+      logging.warn(`transition could/did not run for '${id}', forcing resolution`);
+      if (!hasActiveTransition($element, property)) done(false);
+    }, getResolutionDuration($element, property));
   });
 }
 
 /**
- * Returns all `CSSTransitions` affecting an element.
+ * Returns all `CSSTransitions` currently affecting an element.
  * @param {jQuery} $element
  * @returns {Array<CSSTransition>}
  */
-export function getTransitions($element) {
+export function getActiveTransitions($element) {
   let element = $element;
-  if ($element instanceof $) element = element[0];
+  if (element instanceof $) element = element[0];
   return element.getAnimations().filter(animation => animation instanceof CSSTransition);
 }
 
 /**
+ * Returns a transition object by evaluating the CSS properties of an element.
+ * @param {jQuery} $element
+ * @returns {Object}
+ */
+export function getTransitionsFromCSS($element) {
+  const properties = $element.css('transition-property').split(',').map(property => property.trim());
+  const durations = $element.css('transition-duration').split(',').map(duration => parseFloat(duration));
+  const delays = $element.css('transition-delay').split(',').map(delay => parseFloat(delay));
+  return properties.map((transitionProperty, index) => {
+    // cycle through populated timings as per spec
+    const duration = durations[index % durations.length];
+    const delay = delays[index % delays.length];
+    const timeToEnd = duration + delay;
+    return {
+      transitionProperty,
+      timeToEnd
+    }
+  });
+}
+
+/**
  * Returns whether a `CSSTransition` will be run on an element.
- * An optional `transition-property` can be specified, else all properties will be included.
+ * An optional `transition-property` can be specified, else all properties will be evaluated.
  * @param {jQuery} $element
  * @param {String} property
  * @returns {Boolean}
  */
 export function willTransition($element, property = null) {
+  if (hasActiveTransition($element, property)) return true;
   // `getAnimations()` only populated with `CSSTransitions` following `transitionrun` - use CSS to know if they will run at time of execution
-  const durations = $element.css('transition-duration').split(',').map(duration => parseFloat(duration));
-  const properties = $element.css('transition-property').split(',').map(property => property.trim());
-  const isAllProperty = property === 'all' || properties[0] === 'all';
-  if (!property || isAllProperty) return durations.some(duration => duration > 0);
-  const transitionIndex = properties.findIndex(transitionProperty => transitionProperty === property);
-  if (transitionIndex === -1) return false;
-  // cycle through populated durations as per spec
-  const duration = durations[transitionIndex % durations.length];
-  return Boolean(duration);
+  const transitions = getTransitionsFromCSS($element, property);
+  const isAllProperty = property === 'all' || transitions[0].transitionProperty === 'all';
+  if (!property || isAllProperty) return transitions.some(({ timeToEnd }) => timeToEnd > 0);
+  const transition = transitions.find(({ transitionProperty }) => transitionProperty === property);
+  return transition?.timeToEnd > 0;
 }
 
 /**
  * Returns whether `CSSTransitions` are still active for an element.
- * An optional `transition-property` can be specified, else all properties will be included.
+ * An optional `transition-property` can be specified, else all properties will be evaluated.
  * @param {jQuery} $element
  * @param {String} property
  * @returns {Boolean}
  */
 export function hasActiveTransition($element, property = null) {
-  let transitions = getTransitions($element);
+  let transitions = getActiveTransitions($element);
   if (property) transitions = transitions.filter(({ transitionProperty }) => transitionProperty === property);
   return Boolean(transitions.length);
 }
 
+/**
+ * Returns the resolution duration, by identifying the transition with the longest `timeToEnd` (`transition-duration` + `transition-delay`).
+ * An optional `transition-property` can be specified, else all properties will be evaluated.
+ * @param {jQuery} $element
+ * @param {String} property
+ * @returns {Number}
+ */
+export function getResolutionDuration($element, property = null) {
+  let transitions = getTransitionsFromCSS($element, property);
+  const isAllProperty = property === 'all' || transitions[0].transitionProperty === 'all';
+  if (property && !isAllProperty) transitions = transitions.filter(({ transitionProperty }) => transitionProperty === property);
+  const longestTransition = transitions.slice().sort((a, b) => a.timeToEnd - b.timeToEnd).pop();
+  const buffer = 100;
+  return (longestTransition?.timeToEnd * 1000) + buffer;
+}
+
 export default {
   transitionsEnded,
-  getTransitions,
+  getActiveTransitions,
+  getTransitionsFromCSS,
   willTransition,
-  hasActiveTransition
+  hasActiveTransition,
+  getResolutionDuration
 };

--- a/js/transitions.js
+++ b/js/transitions.js
@@ -26,10 +26,11 @@ export async function transitionsEnded($element, property = null) {
         .off('transitioncancel transitionend', onEnd);
       resolve(didTransition);
     };
-    $element.on('transitionrun', onRun);
-    $element.on('transitioncancel transitionend', onEnd);
+    $element
+      .on('transitionrun', onRun)
+      .on('transitioncancel transitionend', onEnd);
     const resolveInterval = setTimeout(() => {
-      logging.warn('transition could/did not run forcing resolution', $element[0]);
+      logging.warn('transition could/did not run, forcing resolution', $element[0]);
       if (hasActiveTransition($element, property)) return;
       done(false);
     }, timeoutDuration);

--- a/js/transitions.js
+++ b/js/transitions.js
@@ -5,10 +5,10 @@ import logging from 'core/js/logging';
  * An optional `transition-property` to await can be specified, else all properties will be evaluated.
  * @param {jQuery} $element
  * @param {string} [property=null]
- * @returns {Promise}
+ * @returns {Promise<boolean>}
  */
 export async function transitionsEnded($element, property = null) {
-  if (!($element instanceof $)) $element = $($element);
+  $element = $($element).first();
   if (!willTransition($element, property)) return false;
   const longestEndTime = getTransitionsLongestEndTime($element, property);
   const buffer = 100;
@@ -43,6 +43,7 @@ export async function transitionsEnded($element, property = null) {
  * @returns {number}
  */
 export function getTransitionsLongestEndTime($element, property = null) {
+  $element = $($element);
   const properties = $element.css('transition-property').split(',').map(property => property.trim());
   const durations = $element.css('transition-duration').split(',').map(duration => parseFloat(duration));
   const delays = $element.css('transition-delay').split(',').map(delay => parseFloat(delay));
@@ -81,8 +82,7 @@ export function willTransition($element, property = null) {
  * @returns {boolean}
  */
 export function hasActiveTransition($element, property = null) {
-  let element = $element;
-  if (element instanceof $) element = element[0];
+  const element = $($element)[0];
   let transitions = element.getAnimations().filter(animation => animation instanceof window.CSSTransition);
   if (property) transitions = transitions.filter(({ transitionProperty }) => transitionProperty === property);
   return Boolean(transitions.length);

--- a/js/transitions.js
+++ b/js/transitions.js
@@ -4,15 +4,20 @@ import logging from 'core/js/logging';
  * Handler to await completion of active `CSSTransitions`.
  * An optional `transition-property` to await can be specified, else all properties will be evaluated.
  * @param {jQuery} $element
- * @param {String} property
+ * @param {string} [property=null]
  * @returns {Promise}
  */
 export async function transitionsEnded($element, property = null) {
+  if (!($element instanceof $)) $element = $($element);
+  if (!willTransition($element, property)) return false;
+  const longestEndTime = getTransitionsLongestEndTime($element, property);
+  const buffer = 100;
+  const timeoutDuration = longestEndTime + buffer;
   return new Promise(resolve => {
-    if (!($element instanceof $)) $element = $($element);
     const onRun = () => clearTimeout(resolveInterval);
     const onEnd = () => {
-      if (!hasActiveTransition($element, property)) done(true);
+      if (hasActiveTransition($element, property)) return;
+      done(true);
     };
     const done = (didTransition) => {
       clearTimeout(resolveInterval);
@@ -21,101 +26,71 @@ export async function transitionsEnded($element, property = null) {
         .off('transitioncancel transitionend', onEnd);
       resolve(didTransition);
     };
-    if (!willTransition($element, property)) return resolve(false);
     $element.on('transitionrun', onRun);
     $element.on('transitioncancel transitionend', onEnd);
     const resolveInterval = setTimeout(() => {
-      const element = $element[0];
-      const id = element.name || element.id || element.className;
-      logging.warn(`transition could/did not run for '${id}', forcing resolution`);
-      if (!hasActiveTransition($element, property)) done(false);
-    }, getResolutionDuration($element, property));
+      logging.warn('transition could/did not run forcing resolution', $element[0]);
+      if (hasActiveTransition($element, property)) return;
+      done(false);
+    }, timeoutDuration);
   });
 }
 
 /**
- * Returns all `CSSTransitions` currently affecting an element.
+ * Returns the longest end time of the configured transitions
  * @param {jQuery} $element
- * @returns {Array<CSSTransition>}
+ * @param {string} [property=null]
+ * @returns {number}
  */
-export function getActiveTransitions($element) {
-  let element = $element;
-  if (element instanceof $) element = element[0];
-  return element.getAnimations().filter(animation => animation instanceof CSSTransition);
-}
-
-/**
- * Returns a transition object by evaluating the CSS properties of an element.
- * @param {jQuery} $element
- * @returns {Object}
- */
-export function getTransitionsFromCSS($element) {
+export function getTransitionsLongestEndTime($element, property = null) {
   const properties = $element.css('transition-property').split(',').map(property => property.trim());
   const durations = $element.css('transition-duration').split(',').map(duration => parseFloat(duration));
   const delays = $element.css('transition-delay').split(',').map(delay => parseFloat(delay));
-  return properties.map((transitionProperty, index) => {
+  const endTimes = properties.reduce((result, transitionProperty, index) => {
     // cycle through populated timings as per spec
     const duration = durations[index % durations.length];
     const delay = delays[index % delays.length];
-    const timeToEnd = duration + delay;
-    return {
-      transitionProperty,
-      timeToEnd
-    }
-  });
+    const endTime = duration + delay;
+    result[transitionProperty] = endTime;
+    return result;
+  }, {});
+  const isAllProperty = property === 'all' || Boolean(endTimes.all);
+  const longestEndTime = (property && !isAllProperty)
+    ? endTimes[property]
+    : Math.max(...Object.values(endTimes));
+  return (longestEndTime ?? 0) * 1000; // Convert to milliseconds
 }
 
 /**
  * Returns whether a `CSSTransition` will be run on an element.
  * An optional `transition-property` can be specified, else all properties will be evaluated.
  * @param {jQuery} $element
- * @param {String} property
- * @returns {Boolean}
+ * @param {string} [property=null]
+ * @returns {boolean}
  */
 export function willTransition($element, property = null) {
   if (hasActiveTransition($element, property)) return true;
-  // `getAnimations()` only populated with `CSSTransitions` following `transitionrun` - use CSS to know if they will run at time of execution
-  const transitions = getTransitionsFromCSS($element, property);
-  const isAllProperty = property === 'all' || transitions[0].transitionProperty === 'all';
-  if (!property || isAllProperty) return transitions.some(({ timeToEnd }) => timeToEnd > 0);
-  const transition = transitions.find(({ transitionProperty }) => transitionProperty === property);
-  return transition?.timeToEnd > 0;
+  return (getTransitionsLongestEndTime($element, property) > 0);
 }
 
 /**
  * Returns whether `CSSTransitions` are still active for an element.
  * An optional `transition-property` can be specified, else all properties will be evaluated.
  * @param {jQuery} $element
- * @param {String} property
- * @returns {Boolean}
+ * @param {string} [property=null]
+ * @returns {boolean}
  */
 export function hasActiveTransition($element, property = null) {
-  let transitions = getActiveTransitions($element);
+  let element = $element;
+  if (element instanceof $) element = element[0];
+  let transitions = element.getAnimations().filter(animation => animation instanceof window.CSSTransition);
   if (property) transitions = transitions.filter(({ transitionProperty }) => transitionProperty === property);
   return Boolean(transitions.length);
 }
 
-/**
- * Returns the resolution duration, by identifying the transition with the longest `timeToEnd` (`transition-duration` + `transition-delay`).
- * An optional `transition-property` can be specified, else all properties will be evaluated.
- * @param {jQuery} $element
- * @param {String} property
- * @returns {Number}
- */
-export function getResolutionDuration($element, property = null) {
-  let transitions = getTransitionsFromCSS($element, property);
-  const isAllProperty = property === 'all' || transitions[0].transitionProperty === 'all';
-  if (property && !isAllProperty) transitions = transitions.filter(({ transitionProperty }) => transitionProperty === property);
-  const longestTransition = transitions.slice().sort((a, b) => a.timeToEnd - b.timeToEnd).pop();
-  const buffer = 100;
-  return ((longestTransition?.timeToEnd ?? 0) * 1000) + buffer;
-}
-
 export default {
   transitionsEnded,
-  getActiveTransitions,
-  getTransitionsFromCSS,
+  getTransitionsLongestEndTime,
   willTransition,
-  hasActiveTransition,
-  getResolutionDuration
+  hasActiveTransition
 };

--- a/js/transitions.js
+++ b/js/transitions.js
@@ -1,0 +1,76 @@
+/**
+ * Handler to await completion of `CSSTransitions` to be run at point of execution.
+ * An optional `transition-property` to await can be specified, else all properties will be included.
+ * @param {jQuery} $element
+ * @param {String} property
+ * @returns {Promise}
+ */
+export async function transitionsEnded($element, property = null) {
+  return new Promise(resolve => {
+    if (!($element instanceof $)) $element = $($element);
+    // only listen to transitions running after execution
+    const onRun = () => $element.on('transitioncancel transitionend', onEnd);
+    const onEnd = () => {
+      if (!hasActiveTransition($element, property)) done(true);
+    };
+    const done = (didTransition) => {
+      $element
+        .off('transitionrun', onRun)
+        .off('transitioncancel transitionend', onEnd);
+      resolve(didTransition);
+    };
+    $element.on('transitionrun', onRun);
+    if (!willTransition($element, property)) done(false);
+  });
+}
+
+/**
+ * Returns all `CSSTransitions` affecting an element.
+ * @param {jQuery} $element
+ * @returns {Array<CSSTransition>}
+ */
+export function getTransitions($element) {
+  let element = $element;
+  if ($element instanceof $) element = element[0];
+  return element.getAnimations().filter(animation => animation instanceof CSSTransition);
+}
+
+/**
+ * Returns whether a `CSSTransition` will be run on an element.
+ * An optional `transition-property` can be specified, else all properties will be included.
+ * @param {jQuery} $element
+ * @param {String} property
+ * @returns {Boolean}
+ */
+export function willTransition($element, property = null) {
+  // `getAnimations()` only populated with `CSSTransitions` following `transitionrun` - use CSS to know if they will run at time of execution
+  const durations = $element.css('transition-duration').split(',').map(duration => parseFloat(duration));
+  const properties = $element.css('transition-property').split(',').map(property => property.trim());
+  const isAllProperty = property === 'all' || properties[0] === 'all';
+  if (!property || isAllProperty) return durations.some(duration => duration > 0);
+  const transitionIndex = properties.findIndex(transitionProperty => transitionProperty === property);
+  if (transitionIndex === -1) return false;
+  // cycle through populated durations as per spec
+  const duration = durations[transitionIndex % durations.length];
+  return Boolean(duration);
+}
+
+/**
+ * Returns whether `CSSTransitions` are still active for an element.
+ * An optional `transition-property` can be specified, else all properties will be included.
+ * @param {jQuery} $element
+ * @param {String} property
+ * @returns {Boolean}
+ */
+export function hasActiveTransition($element, property = null) {
+  let transitions = getTransitions($element);
+  if (property) transitions = transitions.filter(({ transitionProperty }) => transitionProperty === property);
+  return Boolean(transitions.length);
+}
+
+export default {
+  transitionsEnded,
+  getTransitions,
+  willTransition,
+  hasActiveTransition
+};

--- a/js/transitions.js
+++ b/js/transitions.js
@@ -108,7 +108,7 @@ export function getResolutionDuration($element, property = null) {
   if (property && !isAllProperty) transitions = transitions.filter(({ transitionProperty }) => transitionProperty === property);
   const longestTransition = transitions.slice().sort((a, b) => a.timeToEnd - b.timeToEnd).pop();
   const buffer = 100;
-  return (longestTransition?.timeToEnd * 1000) + buffer;
+  return ((longestTransition?.timeToEnd ?? 0) * 1000) + buffer;
 }
 
 export default {


### PR DESCRIPTION
 Fixes #533.

### New
* Handler to `await` completion of active `CSSTransitions` at point of execution.