### PR TITLE
New: Allow any component to use mobileBody for smaller devices (fixes #538)

### DIFF
--- a/templates/header.jsx
+++ b/templates/header.jsx
@@ -5,11 +5,12 @@ import { classes, prefixClasses, compile } from 'core/js/reactHelpers';
 
 /**
  * Content header for displayTitle, body, instruction text, etc.
- * instruction and mobileInstruction will switch automatically
+ * instruction / mobileInstruction and body / mobileBody will switch automatically
  * @param {Object} props
  * @param {string} [props.displayTitle]
  * @param {string} [props.body]
  * @param {string} [props.instruction]
+ * @param {string} [props.mobileBody]
  * @param {string} [props.mobileInstruction]
  * @param {string} [props._type]
  * @param {string} [props._component]

--- a/templates/header.jsx
+++ b/templates/header.jsx
@@ -5,7 +5,7 @@ import { classes, prefixClasses, compile } from 'core/js/reactHelpers';
 
 /**
  * Content header for displayTitle, body, instruction text, etc.
- * instruction / mobileInstruction and body / mobileBody will switch automatically
+ * body / mobileBody and instruction / mobileInstruction will switch automatically
  * @param {Object} props
  * @param {string} [props.displayTitle]
  * @param {string} [props.body]

--- a/templates/header.jsx
+++ b/templates/header.jsx
@@ -22,6 +22,7 @@ export default function Header(props) {
     displayTitle,
     body,
     instruction,
+    mobileBody,
     mobileInstruction,
     _type,
     _component,
@@ -33,6 +34,9 @@ export default function Header(props) {
       _extension && _extension.toLowerCase()
     ].filter(Boolean)
   } = props;
+  const sizedBody = (mobileBody && !device.isScreenSizeMin('medium')) ?
+    mobileBody :
+    body;
   const sizedInstruction = (mobileInstruction && !device.isScreenSizeMin('medium')) ?
     mobileInstruction :
     instruction;
@@ -69,9 +73,9 @@ export default function Header(props) {
         </div>
         }
 
-        {body &&
+        {sizedBody &&
         <div className={prefixClasses(classNamePrefixes, ['__body'])}>
-          <div className={prefixClasses(classNamePrefixes, ['__body-inner'])} dangerouslySetInnerHTML={{ __html: compile(body, props) }}>
+          <div className={prefixClasses(classNamePrefixes, ['__body-inner'])} dangerouslySetInnerHTML={{ __html: compile(sizedBody, props) }}>
           </div>
         </div>
         }

--- a/templates/partials/component.hbs
+++ b/templates/partials/component.hbs
@@ -13,13 +13,13 @@
 
     {{component_description}}
 
-    {{#if body}}
+    {{#any body mobileBody}}
     <div class="component__body {{lowercase _component}}__body">
       <div class="component__body-inner {{lowercase _component}}__body-inner">
         {{{compile body}}}
       </div>
     </div>
-    {{/if}}
+    {{/any}}
 
     {{#any instruction mobileInstruction}}
     <div class="component__instruction {{lowercase _component}}__instruction">


### PR DESCRIPTION
Fix #538 

### New
* Introduces the `mobileBody` property for component headers

### Testing
1. Add a `body` and `mobileBody` value to any component.
2. Switch to mobile view (less than medium breakpoint) and ensure that body text uses `mobileBody` instead of `body`.
3. Switch back to desktop view (medium breakpoint or higher) and ensure that body text uses `body` instead of `mobileBody`.

### Future consideration
Add `mobileBody` and `mobileInstruction` to the core component schemas. Then, remove them from the schemas of components like [Hot Graphic](https://github.com/adaptlearning/adapt-contrib-hotgraphic/blob/55b26b7fdae55f6c3d97384da2bd39e2d45e6616/schema/component.schema.json#L78) and [Narrative](https://github.com/adaptlearning/adapt-contrib-narrative/blob/c350f7610a0ee927a1259efdd2623e46e2847e94/schema/component.schema.json#L35). Would require migration scripts.