### PR TITLE
Review

### DIFF
--- a/js/transitions.js
+++ b/js/transitions.js
@@ -1,15 +1,71 @@
 import logging from 'core/js/logging';
 
 /**
+ * Returns whether `CSSTransitions` are still active for an element.
+ * An optional `transition-property` can be specified, else all properties will be evaluated.
+ * @param {jQuery} $element
+ * @param {string} [property=null]
+ * @returns {Boolean}
+ */
+function hasActiveTransition($element, property = null) {
+  let element = $element;
+  if (element instanceof $) element = element[0];
+  let transitions = element.getAnimations().filter(animation => animation instanceof window.CSSTransition);
+  if (property) transitions = transitions.filter(({ transitionProperty }) => transitionProperty === property);
+  return Boolean(transitions.length);
+}
+
+/**
+ * Returns the longest end time of the configured transitions
+ * @param {jQuery} $element
+ * @param {string} [property=null]
+ * @returns {Boolean}
+ */
+function getTransitionsLongestEndTime($element, property = null) {
+  const properties = $element.css('transition-property').split(',').map(property => property.trim());
+  const durations = $element.css('transition-duration').split(',').map(duration => parseFloat(duration));
+  const delays = $element.css('transition-delay').split(',').map(delay => parseFloat(delay));
+  const endTimes = properties.reduce((result, transitionProperty, index) => {
+    // cycle through populated timings as per spec
+    const duration = durations[index % durations.length];
+    const delay = delays[index % delays.length];
+    const endTime = duration + delay;
+    result[transitionProperty] = endTime;
+    return result;
+  }, {});
+  const isAllProperty = property === 'all' || Boolean(endTimes.all);
+  const longestEndTime = (property && !isAllProperty)
+    ? endTimes[property]
+    : Object.values(endTimes).sort((a, b) => a.timeToEnd - b.timeToEnd).pop();
+  return (longestEndTime ?? 0) * 1000; // Convert to milliseconds
+}
+
+/**
+ * Returns whether a `CSSTransition` will be run on an element.
+ * An optional `transition-property` can be specified, else all properties will be evaluated.
+ * @param {jQuery} $element
+ * @param {string} [property=null]
+ * @returns {Boolean}
+ */
+function willTransition($element, property = null) {
+  if (hasActiveTransition($element, property)) return true;
+  return (getTransitionsLongestEndTime($element, property) > 0);
+}
+
+/**
  * Handler to await completion of active `CSSTransitions`.
  * An optional `transition-property` to await can be specified, else all properties will be evaluated.
  * @param {jQuery} $element
- * @param {String} property
+ * @param {string} [property=null]
  * @returns {Promise}
  */
 export async function transitionsEnded($element, property = null) {
+  if (!($element instanceof $)) $element = $($element);
+  if (!willTransition($element, property)) return false;
+  const longestEndTime = getTransitionsLongestEndTime($element, property);
+  const buffer = 100;
+  const timeoutDuration = longestEndTime + buffer;
   return new Promise(resolve => {
-    if (!($element instanceof $)) $element = $($element);
     const onRun = () => clearTimeout(resolveInterval);
     const onEnd = () => {
       if (!hasActiveTransition($element, property)) done(true);
@@ -21,101 +77,15 @@ export async function transitionsEnded($element, property = null) {
         .off('transitioncancel transitionend', onEnd);
       resolve(didTransition);
     };
-    if (!willTransition($element, property)) return resolve(false);
     $element.on('transitionrun', onRun);
     $element.on('transitioncancel transitionend', onEnd);
     const resolveInterval = setTimeout(() => {
-      const element = $element[0];
-      const id = element.name || element.id || element.className;
-      logging.warn(`transition could/did not run for '${id}', forcing resolution`);
+      logging.warn('transition could/did not run forcing resolution', $element[0]);
       if (!hasActiveTransition($element, property)) done(false);
-    }, getResolutionDuration($element, property));
+    }, timeoutDuration);
   });
-}
-
-/**
- * Returns all `CSSTransitions` currently affecting an element.
- * @param {jQuery} $element
- * @returns {Array<CSSTransition>}
- */
-export function getActiveTransitions($element) {
-  let element = $element;
-  if (element instanceof $) element = element[0];
-  return element.getAnimations().filter(animation => animation instanceof CSSTransition);
-}
-
-/**
- * Returns a transition object by evaluating the CSS properties of an element.
- * @param {jQuery} $element
- * @returns {Object}
- */
-export function getTransitionsFromCSS($element) {
-  const properties = $element.css('transition-property').split(',').map(property => property.trim());
-  const durations = $element.css('transition-duration').split(',').map(duration => parseFloat(duration));
-  const delays = $element.css('transition-delay').split(',').map(delay => parseFloat(delay));
-  return properties.map((transitionProperty, index) => {
-    // cycle through populated timings as per spec
-    const duration = durations[index % durations.length];
-    const delay = delays[index % delays.length];
-    const timeToEnd = duration + delay;
-    return {
-      transitionProperty,
-      timeToEnd
-    }
-  });
-}
-
-/**
- * Returns whether a `CSSTransition` will be run on an element.
- * An optional `transition-property` can be specified, else all properties will be evaluated.
- * @param {jQuery} $element
- * @param {String} property
- * @returns {Boolean}
- */
-export function willTransition($element, property = null) {
-  if (hasActiveTransition($element, property)) return true;
-  // `getAnimations()` only populated with `CSSTransitions` following `transitionrun` - use CSS to know if they will run at time of execution
-  const transitions = getTransitionsFromCSS($element, property);
-  const isAllProperty = property === 'all' || transitions[0].transitionProperty === 'all';
-  if (!property || isAllProperty) return transitions.some(({ timeToEnd }) => timeToEnd > 0);
-  const transition = transitions.find(({ transitionProperty }) => transitionProperty === property);
-  return transition?.timeToEnd > 0;
-}
-
-/**
- * Returns whether `CSSTransitions` are still active for an element.
- * An optional `transition-property` can be specified, else all properties will be evaluated.
- * @param {jQuery} $element
- * @param {String} property
- * @returns {Boolean}
- */
-export function hasActiveTransition($element, property = null) {
-  let transitions = getActiveTransitions($element);
-  if (property) transitions = transitions.filter(({ transitionProperty }) => transitionProperty === property);
-  return Boolean(transitions.length);
-}
-
-/**
- * Returns the resolution duration, by identifying the transition with the longest `timeToEnd` (`transition-duration` + `transition-delay`).
- * An optional `transition-property` can be specified, else all properties will be evaluated.
- * @param {jQuery} $element
- * @param {String} property
- * @returns {Number}
- */
-export function getResolutionDuration($element, property = null) {
-  let transitions = getTransitionsFromCSS($element, property);
-  const isAllProperty = property === 'all' || transitions[0].transitionProperty === 'all';
-  if (property && !isAllProperty) transitions = transitions.filter(({ transitionProperty }) => transitionProperty === property);
-  const longestTransition = transitions.slice().sort((a, b) => a.timeToEnd - b.timeToEnd).pop();
-  const buffer = 100;
-  return ((longestTransition?.timeToEnd ?? 0) * 1000) + buffer;
 }
 
 export default {
-  transitionsEnded,
-  getActiveTransitions,
-  getTransitionsFromCSS,
-  willTransition,
-  hasActiveTransition,
-  getResolutionDuration
+  transitionsEnded
 };


### PR DESCRIPTION
### transitionsEnded
When `!willTransition`,the return early can be moved to the top of the function before the promise and nested function instantiation.
https://github.com/adaptlearning/adapt-contrib-core/blob/1e5eb32ee87307768c490936c8a4d71b34614e94/js/transitions.js#L24

### getActiveTransitions & getTransitionsFromCSS
The word Transitions in these names refers to two different concepts. The first is an array of `CSSTransition` objects and the second is an array of `{ transitionProperty, timeToEnd }` objects.

### getActiveTransitions & willTransition
`getActiveTransitions` is only used inside `willTransition`, there is probably no need to split this into two functions as the code never repeats.
https://github.com/adaptlearning/adapt-contrib-core/blob/1e5eb32ee87307768c490936c8a4d71b34614e94/js/transitions.js#L85-L96
https://github.com/adaptlearning/adapt-contrib-core/blob/1e5eb32ee87307768c490936c8a4d71b34614e94/js/transitions.js#L36-L45

### willTransition, getResolutionDuration & getTransitionsFromCSS
These functions perform the same behaviour for most of the code. Suggest consolidating the common functionality with  `getTransitionsFromCSS` into a `getTransitionsLongestEndTime` function instead.
https://github.com/adaptlearning/adapt-contrib-core/blob/1e5eb32ee87307768c490936c8a4d71b34614e94/js/transitions.js#L68-L83
https://github.com/adaptlearning/adapt-contrib-core/blob/1e5eb32ee87307768c490936c8a4d71b34614e94/js/transitions.js#L98-L112
https://github.com/adaptlearning/adapt-contrib-core/blob/1e5eb32ee87307768c490936c8a4d71b34614e94/js/transitions.js#L47-L66
The bottom of `getResolutionDuration` is more for offsetting the timeout to run at a goodly position after transition start, it should probably go next to the `setTimeout` call.
https://github.com/adaptlearning/adapt-contrib-core/blob/1e5eb32ee87307768c490936c8a4d71b34614e94/js/transitions.js#L110-L111

### jsDoc comments
* I've changed `String` to `string` as `String` is an instance of `new String()` and `string` is a literal
* I've changed `property` to `[property=null]` as that shows and optional property with a default value