### PR TITLE
Fix: Update deprecated warnings for drawer (fixes #542)

### DIFF
--- a/js/deprecated.js
+++ b/js/deprecated.js
@@ -55,8 +55,8 @@ Adapt.on({
     logging.deprecated('Use drawer.close, Adapt.trigger(\'drawer:closeDrawer\') will be removed in the future');
     drawer.close();
   },
-  'drawer:triggerCustomView'() {
-    logging.deprecated('Use drawer.triggerCustomView(), Adapt.trigger(\'drawer:triggerCustomView\') will be removed in the future');
+  'drawer:openCustomView'() {
+    logging.deprecated('Use drawer.openCustomView(), Adapt.trigger(\'drawer:triggerCustomView\') will be removed in the future');
     drawer.triggerCustomView();
   }
 });

--- a/js/deprecated.js
+++ b/js/deprecated.js
@@ -47,8 +47,8 @@ Adapt.on({
 
 /** START REDUNDANT DRAWER BEHAVIOUR */
 Adapt.on({
-  'drawer:remove'() {
-    logging.deprecated('Use drawer.remove, Adapt.trigger(\'drawer:remove\') will be removed in the future');
+  'drawer:removeDrawer'() {
+    logging.deprecated('Use drawer.remove, Adapt.trigger(\'drawer:removeDrawer\') will be removed in the future');
     drawer.remove();
   },
   'drawer:closeDrawer'() {

--- a/js/deprecated.js
+++ b/js/deprecated.js
@@ -55,7 +55,7 @@ Adapt.on({
     logging.deprecated('Use drawer.close, Adapt.trigger(\'drawer:closeDrawer\') will be removed in the future');
     drawer.close();
   },
-  'drawer:openCustomView'() {
+  'drawer:triggerCustomView'() {
     logging.deprecated('Use drawer.openCustomView(), Adapt.trigger(\'drawer:triggerCustomView\') will be removed in the future');
     drawer.triggerCustomView();
   }


### PR DESCRIPTION
Fix #542 

### Fix
* Update deprecated warning for `drawer.removeDrawer`
* Update deprecated warning for `drawer.triggerCustomView` (other [reference](https://github.com/adaptlearning/adapt-contrib-core/blob/6a0014b60a2d3f5ea20f867ff06f4bc936bac094/js/deprecated.js#L67))