### PR TITLE
Fix: Use dangerouslySetInnerHTML to set attribution text in image.jsx (fixes #544)

### DIFF
--- a/templates/image.jsx
+++ b/templates/image.jsx
@@ -1,7 +1,7 @@
 import device from 'core/js/device';
 import a11y from 'core/js/a11y';
 import React from 'react';
-import { html, classes, prefixClasses } from 'core/js/reactHelpers';
+import { classes, prefixClasses, compile } from 'core/js/reactHelpers';
 
 /**
  * Size switching content image
@@ -49,9 +49,7 @@ export default function Image(props) {
 
       {props.attribution &&
       <span className={prefixClasses(attributionClassNamePrefixes, ['__attribution'])}>
-        <span className={prefixClasses(attributionClassNamePrefixes, ['__attribution-inner'])}>
-          {html(props.attribution)}
-        </span>
+        <span className={prefixClasses(attributionClassNamePrefixes, ['__attribution-inner'])} dangerouslySetInnerHTML={{ __html: compile(props.attribution, props) }} />
       </span>
       }
 

--- a/templates/image.jsx
+++ b/templates/image.jsx
@@ -49,7 +49,10 @@ export default function Image(props) {
 
       {props.attribution &&
       <span className={prefixClasses(attributionClassNamePrefixes, ['__attribution'])}>
-        <span className={prefixClasses(attributionClassNamePrefixes, ['__attribution-inner'])} dangerouslySetInnerHTML={{ __html: compile(props.attribution, props) }} />
+        <span 
+          className={prefixClasses(attributionClassNamePrefixes, ['__attribution-inner'])} 
+          dangerouslySetInnerHTML={{ __html: compile(props.attribution, props) }} 
+        />
       </span>
       }
 

--- a/templates/image.jsx
+++ b/templates/image.jsx
@@ -49,9 +49,9 @@ export default function Image(props) {
 
       {props.attribution &&
       <span className={prefixClasses(attributionClassNamePrefixes, ['__attribution'])}>
-        <span 
-          className={prefixClasses(attributionClassNamePrefixes, ['__attribution-inner'])} 
-          dangerouslySetInnerHTML={{ __html: compile(props.attribution, props) }} 
+        <span
+          className={prefixClasses(attributionClassNamePrefixes, ['__attribution-inner'])}
+          dangerouslySetInnerHTML={{ __html: compile(props.attribution, props) }}
         />
       </span>
       }


### PR DESCRIPTION
Fix #544 

### Fix
* Use `dangerouslySetInnerHTML` to set the attribution text in _image.jsx_
* Compile attribution text so that we can use helpers

### Testing
1. In a Graphic component, set the `_graphic.attribution` value to:

```
{{a11y_alt_text '$5bn' 'five billion dollars'}}
```

2. The attribution text should read `$5bn` with a hidden aria-label of `five billion dollars`

```
<span class="component__attribution graphic__attribution">
  <span class="component__attribution-inner graphic__attribution-inner">
    <span aria-hidden="true">$5bn</span>
    <span class="aria-label">five billion dollars</span>
  </span>
</span>
```