### PR TITLE
New: Allow for instance template overrides (fixes #549)

### DIFF
--- a/js/views/adaptView.js
+++ b/js/views/adaptView.js
@@ -24,7 +24,7 @@ class AdaptView extends Backbone.View {
       'change:_isHidden': this.toggleHidden,
       'change:_isComplete': this.onIsCompleteChange
     });
-    this.isJSX = (this.constructor.template || '').includes('.jsx');
+    this.isJSX = (this.template || this.constructor.template || '').includes('.jsx');
     if (this.isJSX) {
       this._classSet = new Set(_.result(this, 'className').trim().split(/\s+/));
       this.listenTo(this.model, 'change', this.changed);
@@ -100,7 +100,7 @@ class AdaptView extends Backbone.View {
       // Add globals
       _globals: Adapt.course.get('_globals')
     };
-    const Template = templates[this.constructor.template.replace('.jsx', '')];
+    const Template = templates[(this.template || this.constructor.template).replace('.jsx', '')];
     this.updateViewProperties();
     ReactDOM.render(<Template {...props} />, this.el);
   }


### PR DESCRIPTION
Fixes: #549

### New
* Allow for instance template overrides

```js
class TestView extends ComponentView {
  get template() {
    return 'templateName.jsx';
  }
}
```

instead of:

```js
class TestView extends ComponentView {
  // ...
}

TestView.template = 'templateName.jsx';
```