### PR TITLE
Fix: Show static tooltips at end of event loop always

### DIFF
--- a/js/views/TooltipView.js
+++ b/js/views/TooltipView.js
@@ -81,7 +81,7 @@ export default class TooltipView extends Backbone.View {
     const id = $addedEl.data('tooltip-id');
     const tooltip = this.getTooltip(id);
     if (!tooltip?.get('_isEnabled') || !tooltip?.get('_isStatic')) return;
-    this.show(tooltip, $addedEl);
+    _.defer(() => this.show(tooltip, $addedEl));
   }
 
   /**


### PR DESCRIPTION
related https://github.com/adaptlearning/adapt-contrib-hotgraphic/pull/304

This allows safari to catch up on the initial position of the static tooltips, showing them in the correct place.

### Fix
* Show static tooltips at end of event loop always
