### PR TITLE
New: aria label added for partly correct answers (fixes #553)

### DIFF
--- a/js/views/buttonsView.js
+++ b/js/views/buttonsView.js
@@ -189,7 +189,7 @@ export default class ButtonsView extends Backbone.View {
     const correctnessAriaLabel = isCorrect
       ? ariaLabels.answeredCorrectly
       : isPartlyCorrect
-        ? ariaLabels.answeredPartlyCorrect
+        ? (ariaLabels.answeredPartlyCorrect ?? ariaLabels.answeredIncorrectly)
         : ariaLabels.answeredIncorrectly;
     
     if (!hasSpanAriaLabel) {

--- a/js/views/buttonsView.js
+++ b/js/views/buttonsView.js
@@ -177,6 +177,7 @@ export default class ButtonsView extends Backbone.View {
     if (!this.model.shouldShowMarking) return;
 
     const isCorrect = this.model.get('_isCorrect');
+    const isPartlyCorrect = this.model.get('_isPartlyCorrect');
     const ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
 
     const $marking = this.$('.js-btn-marking, .js-btn-marking-label')
@@ -185,13 +186,19 @@ export default class ButtonsView extends Backbone.View {
 
     const $ariaLabel = this.$('.js-btn-marking-label');
     const hasSpanAriaLabel = Boolean($ariaLabel.length);
+    const correctnessAriaLabel = isCorrect
+      ? ariaLabels.answeredCorrectly
+      : isPartlyCorrect
+        ? ariaLabels.answeredPartlyCorrect
+        : ariaLabels.answeredIncorrectly;
+    
     if (!hasSpanAriaLabel) {
       // Backward compability
-      $marking.attr('aria-label', isCorrect ? ariaLabels.answeredCorrectly : ariaLabels.answeredIncorrectly);
+      $marking.attr('aria-label', correctnessAriaLabel);
       return;
     }
 
-    $ariaLabel.html(isCorrect ? ariaLabels.answeredCorrectly : ariaLabels.answeredIncorrectly);
+    $ariaLabel.html(correctnessAriaLabel);
   }
 
   refresh() {


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-core/issues/553

### New
Requires `answeredPartlyCorrect` aria label added to course __globals_  (FW PR https://github.com/adaptlearning/adapt_framework/pull/3570).

### Testing
You can test the following either by running a screen reader or inspect the button marking label `.js-btn-marking-label` (button marking displays bewteen the _show answer_ / _feedback_ buttons.

1. Test with FW branch [issue/3565](https://github.com/adaptlearning/adapt_framework/tree/issue/3565)
2. Using the Adapt course, go to Matching component c-225.
3. Answer the Matching component as per below to test correct, partially correct and incorrect aria labels are used. 
  - correct answers - item 1: 2013, item 2: 2008, item 3: Hebrew
  - partly correct answers - item 1: 2013, item 2: 2013, item 3: Esperanto
  - incorrect answer - item 1: 2008, item 2: 2013, item 3: Esperanto




