### PR TITLE
Fix: heading completion selector added to aria-label (fixes #561)

### DIFF
--- a/js/views/headingView.js
+++ b/js/views/headingView.js
@@ -26,7 +26,7 @@ class HeadingView extends Backbone.View {
     const template = Handlebars.templates[this.constructor.template];
     const data = this.model.toJSON();
     const $rendered = $(`<div>${template(data)}</div>`);
-    this.$('.aria-label').html($rendered.find('.aria-label').html());
+    this.$('.js-a11y-completion-description').html($rendered.find('.js-a11y-completion-description').html());
     this.checkCompletion();
   }
 

--- a/templates/heading.hbs
+++ b/templates/heading.hbs
@@ -1,7 +1,7 @@
 {{import_globals}}
 
 <div id="{{_id}}-heading" class="js-heading-inner" role="heading" aria-level="{{a11y_aria_level _id _type _ariaLevel}}">
-  <span class="aria-label">
+  <span class="aria-label js-a11y-completion-description">
   {{#if _isA11yCompletionDescriptionEnabled}}
     {{#if _isOptional}}
       {{else if _isComplete}}


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-core/issues/561

### Fix
Added `.js-a11y-completion-description` selector to heading completion aria-label instead of targeting generic `.aria-label` selector to update completion. 

This will prevent functionality clashes between elements of a shared selector. For example, using `a11y_alt_text` [helper](https://github.com/adaptlearning/adapt-contrib-core/blob/0e1fe9e23853421b90dacbd5bb886caf24df7c8b/js/helpers.js#L364) within a `displayTitle`, as per the associated issue.

### Testing
1. Use the `a11y_alt_text` helper within a `displayTitle`. Note, you'll need to test this on a component that requires interaction rather than in view completion. For example, an Accordion title.
`"displayTitle": "I wish I had {{a11y_alt_text '$5bn' 'five billion dollars'}}",`

2. Go to the title within your course and inspect (or use a screen reader). 
Title should read "Incomplete. I wish I had five billion dollars"

3. Interact with component so all items complete.
Title should read "Complete. I wish I had five billion dollars"

[//]: # (Mention any other dependencies)


