### PR TITLE
Fix: Do not trigger location update when location hasn't changed (fixes #569)

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -356,6 +356,8 @@ class Router extends Backbone.Router {
   }
 
   async updateLocation(currentLocation, type, id, currentModel) {
+    if (location._currentId === id) return;
+
     // Handles updating the location.
     location._previousModel = location._currentModel;
     location._previousId = location._currentId;


### PR DESCRIPTION
fixes #569 

### Fix
* Do not trigger a `router:location` event when `router.updateLocation` is called without changing location