### PR TITLE
Fix: Emit router:location on contentObject reload

### DIFF
--- a/js/router.js
+++ b/js/router.js
@@ -356,7 +356,7 @@ class Router extends Backbone.Router {
   }
 
   async updateLocation(currentLocation, type, id, currentModel) {
-    if (location._currentId === id) return;
+    if (location._currentId === id && id === null) return;
 
     // Handles updating the location.
     location._previousModel = location._currentModel;


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt-contrib-assessment/issues/204

### Fix
* Emit router:location on contentObject reload but not on language location reset