### PR TITLE
Fix: Remove aria-label from images when alt text is empty (fixes #574)

### DIFF
--- a/templates/image.jsx
+++ b/templates/image.jsx
@@ -40,7 +40,7 @@ export default function Image(props) {
           props?._srcFocalPoint && `object-position-${props?._srcFocalPoint}`
         ])}
         src={src}
-        aria-label={a11y.normalize(props.alt)}
+        aria-label={props.alt ? a11y.normalize(props.alt) : null}
         aria-hidden={!props.alt}
         loading='eager'
         aria-describedby={props.longdescription ? props.longDescriptionId : undefined}


### PR DESCRIPTION
Fix #574 

### Fix
* Removes the `aria-label` attribute from images when alt text is empty

### Testing
In plugins that use the core `image.jsx` template (e.g. the [Graphic](https://github.com/adaptlearning/adapt-contrib-graphic) component), set the `alt` property in the JSON config to an empty string. The `aria-label` attribute should not be present.