### PR TITLE
Fix: DisplayTitle default removed from content and moved to specific schemas (fixes #580)

### DIFF
--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -15,6 +15,9 @@
           "type": "string",
           "title": "Component"
         },
+        "displayTitle": {
+          "default": "Untitled"
+        },
         "_layout": {
           "type": "string",
           "title": "Layout",

--- a/schema/content.schema.json
+++ b/schema/content.schema.json
@@ -37,7 +37,7 @@
       "type": "string",
       "title": "Display title",
       "description": "When viewing an element - this is the title that will be displayed on the page",
-      "default": "Untitled",
+      "default": "",
       "_adapt": {
         "translatable": true
       },

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -8,6 +8,9 @@
     },
     "with": {
       "properties": {
+        "displayTitle": {
+          "default": "Untitled"
+        },
         "subtitle": {
           "type": "string",
           "title": "Subtitle",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -8,6 +8,9 @@
     },
     "with": {
       "properties": {
+        "displayTitle": {
+          "default": "Untitled"
+        },
         "heroImage": {
           "type": "string",
           "isObjectId": true,


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
#580 

ref: The update in schemas is needed to ensure that default displayTitles are not applied to articles and blocks to speed up AAT workflow. As discussed legacy schemas are to be left with existing functionality. 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* DisplayTitle default removed from content and moved to specific schemas (fixes #580)

