### PR TITLE
Fix: Allow tooltips to follow animations

### DIFF
--- a/js/views/adaptView.js
+++ b/js/views/adaptView.js
@@ -136,6 +136,8 @@ class AdaptView extends Backbone.View {
       const minVerticalInview = onscreen._percentInviewVertical || 33;
       if (m.percentInviewVertical < minVerticalInview) return;
       this.$el.addClass(`${onscreen._classes}-after`).off('onscreen.adaptView');
+      const type = this.model.get('_type');
+      Adapt.trigger(`${type}View:animationStart view:animationStart`, this);
     });
   }
 


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt-contrib-hotgraphic/issues/319

When animating the parent of a tooltip, the tooltip will follow the parent element.

### Fix
* Introduce animation loop for tooltip movement, triggered on onscreen animationStart, contentObjectView:ready and device:resize

### Testing
* Add an onscreen animation to the hotgraphic's block and scroll it into view
