### PR TITLE
New: _isLocked becomes a lockable attribute

### DIFF
--- a/js/models/adaptModel.js
+++ b/js/models/adaptModel.js
@@ -49,6 +49,12 @@ export default class AdaptModel extends LockingModel {
     };
   }
 
+  lockedAttributes() {
+    return {
+      _isLocked: true
+    };
+  }
+
   /**
    * Fetch an array representing the relative location of the model to the nearest _trackingId
    * @returns {Array<Number, Number>}
@@ -780,7 +786,7 @@ export default class AdaptModel extends LockingModel {
           !previousChild.get('_isComplete') &&
           !previousChild.get('_isOptional')
         );
-      child.set('_isLocked', isLockedByPreviousChild);
+      child.set('_isLocked', isLockedByPreviousChild, { pluginName: 'adapt' });
     }, false);
   }
 
@@ -788,19 +794,19 @@ export default class AdaptModel extends LockingModel {
     const children = this.getAvailableChildModels();
     const firstChild = children.shift();
     const isLockedByFirstChild = (!firstChild.get('_isComplete') && !firstChild.get('_isOptional'));
-    children.forEach(child => child.set('_isLocked', isLockedByFirstChild));
+    children.forEach(child => child.set('_isLocked', isLockedByFirstChild, { pluginName: 'adapt' }));
   }
 
   setLockLastLocking() {
     const children = this.getAvailableChildModels();
     const lastChild = children.pop();
     const isLockedByChildren = children.some(child => (!child.get('_isComplete') && !child.get('_isOptional')));
-    lastChild.set('_isLocked', isLockedByChildren);
+    lastChild.set('_isLocked', isLockedByChildren, { pluginName: 'adapt' });
   }
 
   setCustomLocking() {
     const children = this.getAvailableChildModels();
-    children.forEach(child => child.set('_isLocked', this.shouldLock(child)));
+    children.forEach(child => child.set('_isLocked', this.shouldLock(child), { pluginName: 'adapt' }));
   }
 
   shouldLock(child) {

--- a/js/models/adaptModel.js
+++ b/js/models/adaptModel.js
@@ -856,6 +856,8 @@ export default class AdaptModel extends LockingModel {
     const ModelClass = this.constructor;
     // Clone the model
     const clonedModel = new ModelClass(this.toJSON());
+    clonedModel._lockedAttributes = { ...this._lockedAttributes };
+    clonedModel._lockedAttributesValues = { ...this._lockedAttributesValues };
     // Run the custom modifier on the clone
     if (modifier) {
       modifier(clonedModel, this);

--- a/js/models/lockingModel.js
+++ b/js/models/lockingModel.js
@@ -49,7 +49,9 @@ export default class LockingModel extends Backbone.Model {
       const isAttemptingToLock = (lockingValue === attrVal);
 
       if (isAttemptingToLock) {
-        this.setLockState(attrName, true, { pluginName, skipcheck: true });
+        if (!isInitialDefault) {
+          this.setLockState(attrName, true, { pluginName, skipcheck: true });
+        }
         newValues[attrName] = lockingValue;
         continue;
       }

--- a/js/models/questionModel.js
+++ b/js/models/questionModel.js
@@ -49,6 +49,12 @@ class QuestionModel extends ComponentModel {
     ]);
   }
 
+  lockedAttributes() {
+    return ComponentModel.resultExtend('lockedAttributes', {
+      _canSubmit: true
+    });
+  }
+
   /**
    * Returns a string of the model type group.
    * @returns {string}
@@ -59,7 +65,6 @@ class QuestionModel extends ComponentModel {
 
   init() {
     this.setupDefaultSettings();
-    this.setLocking('_canSubmit', true);
     this.updateRawScore();
     super.init();
   }


### PR DESCRIPTION
part of #584 

### New
* _isLocked becomes a lockable attribute allowing plugins to force _isLocked: true

### Fix
* Do not lock when setting initial defaults (this can occur when cloning a model)
* Make sure to copy locked attribute states on ComponentModel.deepClone
* Clarified QuestionModel._canSubmit locking as model properties rather than an init function call

### Notes
* The core will softly warn to the console in the period between this change and changing other plugins (trickle) to provide their pluginName when setting _isLocked.

requires https://github.com/adaptlearning/adapt-contrib-trickle/pull/231
