### PR TITLE
Update: Move notify title above body text (fix #586)

### DIFF
--- a/less/core/notify.less
+++ b/less/core/notify.less
@@ -42,7 +42,7 @@
         flex-direction: row;
         column-gap: 1rem;
 
-        .notify__body {
+        .notify__text {
           width: 60%;
         }
     

--- a/templates/notifyPopup.hbs
+++ b/templates/notifyPopup.hbs
@@ -14,11 +14,13 @@
         {{/if}}
 
         {{#if title}}
+        {{#unless _graphic._src}}
         <div class="notify__title{{#if isAltTitle}} aria-label{{/if}}" id="notify-heading">
           <div class="notify__title-inner" role="heading" aria-level="{{a11y_aria_level _id 'notify' _ariaLevel}}">
             {{{compile title}}}
           </div>
         </div>
+        {{/unless}}
         {{/if}}
 
         {{#any _graphic._src body}}
@@ -40,13 +42,23 @@
             {{~/any~}}
             {{~/if~}}
 
-            {{~#if body~}}
-            <div class="notify__body">
-              <div class="notify__body-inner">
-                {{{compile body}}}
+            <div class="notify__text">
+              {{#all title _graphic._src}}
+              <div class="notify__title{{#if isAltTitle}} aria-label{{/if}}" id="notify-heading">
+                <div class="notify__title-inner" role="heading" aria-level="{{a11y_aria_level _id 'notify' _ariaLevel}}">
+                  {{{compile title}}}
+                </div>
               </div>
+              {{/all}}
+
+              {{~#if body~}}
+              <div class="notify__body">
+                <div class="notify__body-inner">
+                  {{{compile body}}}
+                </div>
+              </div>
+              {{~/if~}}
             </div>
-            {{~/if~}}
 
             {{~#if _graphic._src~}}
             {{~#any (equals _imageAlignment 'right') (equals _imageAlignment 'bottom')~}}

--- a/templates/notifyPopup.hbs
+++ b/templates/notifyPopup.hbs
@@ -13,17 +13,6 @@
         </div>
         {{/if}}
 
-        {{#if title}}
-        {{#unless _graphic._src}}
-        <div class="notify__title{{#if isAltTitle}} aria-label{{/if}}" id="notify-heading">
-          <div class="notify__title-inner" role="heading" aria-level="{{a11y_aria_level _id 'notify' _ariaLevel}}">
-            {{{compile title}}}
-          </div>
-        </div>
-        {{/unless}}
-        {{/if}}
-
-        {{#any _graphic._src body}}
         <div class="notify__section">
           <div class="notify__section-inner">
 
@@ -43,13 +32,13 @@
             {{~/if~}}
 
             <div class="notify__text">
-              {{#all title _graphic._src}}
+              {{#if title}}
               <div class="notify__title{{#if isAltTitle}} aria-label{{/if}}" id="notify-heading">
                 <div class="notify__title-inner" role="heading" aria-level="{{a11y_aria_level _id 'notify' _ariaLevel}}">
                   {{{compile title}}}
                 </div>
               </div>
-              {{/all}}
+              {{/if}}
 
               {{~#if body~}}
               <div class="notify__body">
@@ -77,7 +66,6 @@
 
           </div>
         </div>
-        {{/any}}
 
         {{#equals _type "alert"}}
         <div class="notify__btn-container">


### PR DESCRIPTION
Fix #586 

### Update
* Moves the notify title directly above the body text
* Applies to Notify popups that use `notifyPopup.hbs`
* Adds a `.notify__text` wrapper to the body and text area

### Questions
1. Should this be a configuration option or just the default behavior?
2. Are there any use cases that this will break?
3. What are the disadvantages for using this layout? Is it a bad idea?

### Testing
1. Add feedback with images. For example:

```
"_feedback": {
  "title": "Feedback",
  "_correct": {
    "title": "Correct feedback text.",
    "body": "That’s correct. Aliquip id nisi sunt do sint. Laboris nisi nisi Lorem tempor non proident. Nulla laboris ad incididunt irure officia cillum incididunt esse sunt laborum.",
    "_imageAlignment": "left",
    "_graphic": {
      "_src": "course/en/images/correct.jpg",
      "alt": "Correct"
    }
  },
  "_incorrectFinal": {
    "title": "Incorrect feedback text.",
    "body": "That’s not right. Elit dolore Lorem proident mollit ipsum pariatur dolore. Labore amet enim minim excepteur duis. Nulla eu mollit culpa veniam culpa sint adipisicing. Anim cupidatat do do mollit pariatur et.",
    "_imageAlignment": "right",
    "_graphic": {
      "_src": "course/en/images/incorrect.jpg",
      "alt": "Incorrect"
    }
  }
},
```
2. Test without images as well.