### PR TITLE
Fix: locked attributes with conflicting default value

### DIFF
--- a/js/models/lockingModel.js
+++ b/js/models/lockingModel.js
@@ -32,11 +32,8 @@ export default class LockingModel extends Backbone.Model {
       const defaults = _.result(this, 'defaults');
       const isDefault = (defaults[attrName] !== undefined);
       const isInitialDefault = (isDefault && !this.changed);
-      if (isInitialDefault) {
-        this._lockedAttributes[attrName] = !defaults[attrName];
-      }
-
       const isSettingValueForSpecificPlugin = options?.pluginName;
+
       if (!isSettingValueForSpecificPlugin) {
         if (!isInitialDefault) {
           console.error('Must supply a pluginName to change a locked attribute');
@@ -65,7 +62,7 @@ export default class LockingModel extends Backbone.Model {
       }
     }
 
-    if (!Object.keys(newValues)) return this;
+    if (!Object.keys(newValues).length) return this;
 
     super.set(newValues, options);
 


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt-contrib-instructionError/issues/11

This bug arose as a consequence of https://github.com/adaptlearning/adapt-contrib-core/pull/585 moving `_canSubmit` into `lockedAttributes`.

### Fix
* Where model default[lockedAttributeName] is the same as lockedAttributes[lockedAttributeName] the lockingModel no longer overrides the locking value ([_canSubmit](https://github.com/adaptlearning/adapt-contrib-core/blob/c7ab17d99ae1d39c35a8e3abe848991d78ddc928/js/models/questionModel.js#L23-L55) question model with [adapt-contrib-instructionError](https://github.com/adaptlearning/adapt-contrib-instructionError))
* Invalid return early in existence check 