### PR TITLE
New: Add "has-error" class for use with question components (fixes #594)

### DIFF
--- a/js/views/questionView.js
+++ b/js/views/questionView.js
@@ -244,8 +244,8 @@ class QuestionView extends ComponentView {
   }
 
   showInstructionError() {
-    Adapt.trigger('questionView:showInstructionError', this);
     this.model.toggleClass('has-error', true);
+    Adapt.trigger('questionView:showInstructionError', this);
   }
 
   // Blank method for question to fill out when the question cannot be submitted

--- a/js/views/questionView.js
+++ b/js/views/questionView.js
@@ -245,9 +245,6 @@ class QuestionView extends ComponentView {
 
   showInstructionError() {
     Adapt.trigger('questionView:showInstructionError', this);
-  }
-
-  addErrorClass() {
     this.model.toggleClass('has-error', true);
   }
 

--- a/js/views/questionView.js
+++ b/js/views/questionView.js
@@ -49,7 +49,6 @@ class QuestionView extends ComponentView {
   preRender() {
     this.listenTo(this.model, {
       'change:_isEnabled': this.onEnabledChanged,
-      'change:_isSubmitted': this.onSubmittedChanged,
       'question:refresh': this.refresh
     });
 
@@ -78,11 +77,6 @@ class QuestionView extends ComponentView {
       this.enableQuestion();
     }
 
-  }
-
-  onSubmittedChanged(model) {
-    // Remove error class, if it exists
-    model.toggleClass('has-error', false);
   }
 
   // Used by the question to disable the question during submit and complete stages
@@ -179,6 +173,8 @@ class QuestionView extends ComponentView {
     // and give a blank method, onCannotSubmit to the question
     const canSubmit = this._runModelCompatibleFunction('canSubmit');
 
+    this.model.toggleClass('has-error', !canSubmit);
+
     if (!canSubmit) {
       this.showInstructionError();
       this.onCannotSubmit();
@@ -243,7 +239,6 @@ class QuestionView extends ComponentView {
   }
 
   showInstructionError() {
-    this.model.toggleClass('has-error', true);
     Adapt.trigger('questionView:showInstructionError', this);
   }
 

--- a/js/views/questionView.js
+++ b/js/views/questionView.js
@@ -49,7 +49,7 @@ class QuestionView extends ComponentView {
   preRender() {
     // Setup listener for _isEnabled
     this.listenTo(this.model, 'change:_isEnabled', this.onEnabledChanged);
-
+    this.listenTo(this.model, 'change:_isSubmitted', this.onSubmittedChanged);
     this.listenTo(this.model, 'question:refresh', this.refresh);
 
     // Checks to see if the question should be reset on revisit
@@ -77,6 +77,11 @@ class QuestionView extends ComponentView {
       this.enableQuestion();
     }
 
+  }
+
+  onSubmittedChanged(model) {
+    // Remove error class, if it exists
+    model.toggleClass('has-error', false);
   }
 
   // Used by the question to disable the question during submit and complete stages
@@ -175,6 +180,7 @@ class QuestionView extends ComponentView {
 
     if (!canSubmit) {
       this.showInstructionError();
+      this.addErrorClass();
       this.onCannotSubmit();
       return;
     }
@@ -238,6 +244,10 @@ class QuestionView extends ComponentView {
 
   showInstructionError() {
     Adapt.trigger('questionView:showInstructionError', this);
+  }
+
+  addErrorClass() {
+    this.model.toggleClass('has-error', true);
   }
 
   // Blank method for question to fill out when the question cannot be submitted

--- a/js/views/questionView.js
+++ b/js/views/questionView.js
@@ -47,10 +47,11 @@ class QuestionView extends ComponentView {
   }
 
   preRender() {
-    // Setup listener for _isEnabled
-    this.listenTo(this.model, 'change:_isEnabled', this.onEnabledChanged);
-    this.listenTo(this.model, 'change:_isSubmitted', this.onSubmittedChanged);
-    this.listenTo(this.model, 'question:refresh', this.refresh);
+    this.listenTo(this.model, {
+      'change:_isEnabled': this.onEnabledChanged,
+      'change:_isSubmitted': this.onSubmittedChanged,
+      'question:refresh': this.refresh
+    });
 
     // Checks to see if the question should be reset on revisit
     if (this.checkIfResetOnRevisit !== QuestionView.prototype.checkIfResetOnRevisit) {

--- a/js/views/questionView.js
+++ b/js/views/questionView.js
@@ -181,7 +181,6 @@ class QuestionView extends ComponentView {
 
     if (!canSubmit) {
       this.showInstructionError();
-      this.addErrorClass();
       this.onCannotSubmit();
       return;
     }


### PR DESCRIPTION
Fix #594 

### New
* Adds the error class `has-error` to question components when the question cannot be submitted.

### Testing
1. Install and enable [Instruction Error](https://github.com/adaptlearning/adapt-contrib-instructionError) which will allow you to submit a question before it is completed (ex. before an option is selected in an MCQ)
2. Select the "Submit" button before making a choice
3. The component should now have the `has-error` class.
4. Next, make a selection for the question. If the question has multiple items (e.g. Matching), make a selection for every item.
5. Select the "Submit" button
6. The `has-error` class should be removed.
