### PR TITLE
Fix: inview reprocess on window resize (fixes #596)

### DIFF
--- a/libraries/inview.js
+++ b/libraries/inview.js
@@ -48,6 +48,7 @@
       process();
     }
   };
+  $(window).on('resize', wndw.resize);
   // handler functions
   function register(element, data, type) {
     const observer = new IntersectionObserver(entries => {


### PR DESCRIPTION
fixes #596 

Inview was using old window dimensions to measure inview positions. These must be recalculated when the window is resized.

### Fix
* Trigger reprocess on window resize