### PR TITLE
Fix: inview return undefined when no element supplied (fixes #598)

### DIFF
--- a/libraries/inview.js
+++ b/libraries/inview.js
@@ -156,6 +156,7 @@
     return locks.includes(name);
   }
   function getMeasurement (element) {
+    if (!element?.getBoundingClientRect) return;
     const offset = element.getBoundingClientRect();
     const height = offset.height;
     const width = offset.width;


### PR DESCRIPTION
fixes #598 

### Fix
* Allow running `onscreen()` with no elements