### PR TITLE
Fix: Popup support in a11y disabled (fixes #616)

### DIFF
--- a/js/a11y/popup.js
+++ b/js/a11y/popup.js
@@ -89,16 +89,16 @@ export default class Popup extends Backbone.Controller {
    */
   _addPopupLayer($popupElement) {
     $popupElement = $($popupElement);
-    const config = this.a11y.config;
-    if (!config._isEnabled || !config._options._isPopupManagementEnabled || $popupElement.length === 0) {
-      return $popupElement;
-    }
     this._floorStack.push($popupElement);
     this._focusStack.push($(document.activeElement));
     if ($popupElement.is('dialog')) {
       $popupElement[0].addEventListener('cancel', event => event.preventDefault());
       $popupElement[0].showModal();
       return;
+    }
+    const config = this.a11y.config;
+    if (!config._isEnabled || !config._options._isPopupManagementEnabled || $popupElement.length === 0) {
+      return $popupElement;
     }
     logging.deprecated('a11y/popup opened: Use native dialog tag for', $popupElement);
     let $elements = $(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes);
@@ -166,10 +166,6 @@ export default class Popup extends Backbone.Controller {
    * @returns {Object} Returns previously active element.
    */
   _removeLastPopupLayer() {
-    const config = this.a11y.config;
-    if (!config._isEnabled || !config._options._isPopupManagementEnabled) {
-      return $(document.activeElement);
-    }
     // the body layer is the first element and must always exist
     if (this._floorStack.length <= 1) {
       return;
@@ -178,6 +174,10 @@ export default class Popup extends Backbone.Controller {
     if ($popupElement.is('dialog')) {
       $popupElement[0].close();
       return this._focusStack.pop();
+    }
+    const config = this.a11y.config;
+    if (!config._isEnabled || !config._options._isPopupManagementEnabled) {
+      return $(document.activeElement);
     }
     $(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes).each((index, item) => {
       const $item = $(item);


### PR DESCRIPTION
fixes #616 

### Fix
* Enable popup support when config.json:`_accessibility._isEnabled: false`
