### PR TITLE
New: Use build.timestamp to force json reload

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -34,7 +34,7 @@ class Data extends AdaptCollection {
   async init () {
     this.reset();
     this._byAdaptID = {};
-    Adapt.build = new BuildModel(null, { url: 'adapt/js/build.min.js', reset: true });
+    Adapt.build = new BuildModel(null, { url: `adapt/js/build.min.js?timestamp=${Date.now()}`, reset: true });
     await Adapt.build.whenReady();
     $('html').attr('data-adapt-framework-version', Adapt.build.get('package').version);
     this.loadConfigData();
@@ -49,7 +49,7 @@ class Data extends AdaptCollection {
   }
 
   loadConfigData() {
-    Adapt.config = new ConfigModel(null, { url: Adapt.build.get('coursedir') + '/config.' + Adapt.build.get('jsonext'), reset: true });
+    Adapt.config = new ConfigModel(null, { url: Adapt.build.get('coursedir') + '/config.' + Adapt.build.get('jsonext') + `?timestamp=${Adapt.build.get('timestamp')}`, reset: true });
     this.listenToOnce(Adapt, 'configModel:loadCourseData', this.onLoadCourseData);
     this.listenTo(Adapt.config, {
       'change:_activeLanguage': this.onLanguageChange,
@@ -134,7 +134,7 @@ class Data extends AdaptCollection {
     let allFileData;
     try {
       allFileData = await Promise.all(manifest.map(filePath => {
-        return this.getJSON(`${languagePath}${filePath}`);
+        return this.getJSON(`${languagePath}${filePath}?timestamp=${Adapt.build.get('timestamp')}`);
       }));
     } catch (error) {
       logging.error(error);

--- a/required/index.html
+++ b/required/index.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Adapt</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="adapt.css" type="text/css" rel="stylesheet">
+    <link href="adapt.css?timestamp=@@build.timestamp" type="text/css" rel="stylesheet">
     <script src="libraries/modernizr.js"></script>
     <script src="adapt/js/scriptLoader.js"></script>
   </head>


### PR DESCRIPTION
part of https://github.com/adaptlearning/adapt_framework/issues/3649
requires  https://github.com/adaptlearning/adapt_framework/pull/3650
requires https://github.com/adaptlearning/adapt-contrib-spoor/pull/336

### New
* Force download `build.min.js` for fresh `Adapt.build.get('timestamp')`
* Force fresh json according to `Adapt.build.get('timestamp')`
* Force fresh css according to `@@build.timestamp`