### PR TITLE
Fix: Force body focus (fixes #626)

### DIFF
--- a/js/a11y.js
+++ b/js/a11y.js
@@ -730,6 +730,12 @@ class A11y extends Backbone.Controller {
   focusFirst($element, options) {
     options = new FocusOptions(options);
     $element = $($element).first();
+    const isBodyFocus = ($element[0] === document.body);
+    if (isBodyFocus) {
+      // force focus to the body, effectively starting the tab cursor from the top
+      this.focus($element, options);
+      return;
+    }
     if (this.isReadable($element)) {
       this.focus($element, options);
       return $element;


### PR DESCRIPTION
fixes #626

When the router tries to focus on the `document.body` here:
https://github.com/adaptlearning/adapt-contrib-core/blob/230a2fa1ae12b6f1e854cb98964fc540286c55b7/js/router.js#L507

This pr forces the focus to the body element rather than trying to find the first focusable element - which had previously been the skip navigation button.

The outcome is that the body has focus making the window scrollable with the up/down arrows and then the first tab takes the learner to the skip navigation button, as before.

### Fix
* `a11y.focusFirst(document.body)` forces focus to body rather than first focusable element