### PR TITLE
Fix: Perform HTMLDialogElement.close on drawer before animating closed (fixes #628)

### DIFF
--- a/js/views/drawerView.js
+++ b/js/views/drawerView.js
@@ -221,6 +221,8 @@ class DrawerView extends Backbone.View {
     if (!this._isVisible) return;
     this._useMenuPosition = false;
 
+    a11y.popupClosed($toElement);
+
     this._isCustomViewVisible = false;
     shadow.hide();
 
@@ -233,7 +235,6 @@ class DrawerView extends Backbone.View {
     $('.js-nav-drawer-btn').attr('aria-expanded', false);
     Adapt.trigger('drawer:closed');
 
-    a11y.popupClosed($toElement);
     this._isVisible = false;
     a11y.scrollEnable('body');
     this.$('.js-drawer-holder').removeAttr('role');


### PR DESCRIPTION
Additional fixes to pr https://github.com/adaptlearning/adapt-contrib-core/pull/601

fixes #628 

When plp navigates to a different page it causes both the drawer to close and the pip notify to open. The drawer dialog should be closed before the notify is open such that the drawer close doesn't accidentally close the new notify at https://github.com/adaptlearning/adapt-contrib-core/blob/230a2fa1ae12b6f1e854cb98964fc540286c55b7/js/a11y/popup.js#L168-L176

Reverting to previous behaviour in v6.60.2
https://github.com/adaptlearning/adapt-contrib-core/blob/a1b6c57f8608d0a38ef6918ce3bc9bad6961f580/js/views/drawerView.js#L194-L198

### Fix
* Perform HTMLDialogElement.close on drawer before animating closed
