### PR TITLE
Fix: trigger `inview` and `onscreen` events when element off screen

### DIFF
--- a/libraries/inview.js
+++ b/libraries/inview.js
@@ -96,7 +96,7 @@
       item.uniqueMeasurementId !== uniqueMeasurementId
     );
     item.uniqueMeasurementId = measurement.uniqueMeasurementId;
-    if (!hasMeasureChanged || !measurement.onscreen) return;
+    if (!hasMeasureChanged) return;
     switch (item.type) {
       case TYPE.onscreen:
         processOnScreen(item, measurement);


### PR DESCRIPTION
Fixes #630.

### Fix
* Trigger `inview` and `onscreen` events when element off screen