### PR TITLE
Fix: add scroll padding to body to avoid focus obscured issue (fixes #635

### DIFF
--- a/less/core/accessibility.less
+++ b/less/core/accessibility.less
@@ -1,10 +1,9 @@
 // prevent elements from being obscured by nav bar when they receive focus
-body {
-  .is-nav-bottom & {
+:not(.adapt-scrolling), .adapt-scrolling body {
+  .is-nav-bottom& {
     scroll-padding-bottom: var(--adapt-navigation-height);
   }
-
-  .is-nav-top & {
+  .is-nav-top& {
     scroll-padding-top: var(--adapt-navigation-height);
   }
 }

--- a/less/core/accessibility.less
+++ b/less/core/accessibility.less
@@ -1,3 +1,14 @@
+// prevent elements from being obscured by nav bar when they receive focus
+body {
+  .is-nav-bottom & {
+    scroll-padding-bottom: var(--adapt-navigation-height);
+  }
+
+  .is-nav-top & {
+    scroll-padding-top: var(--adapt-navigation-height);
+  }
+}
+
 // To allow children elements to be positioned absolutely
 // --------------------------------------------------
 .component { position: relative; }


### PR DESCRIPTION
fixes #635

### Fix
* Add scroll padding to `body` to avoid focus from being obscured by navbar

### Testing
1. Press tab to move focus to a focusable element.
2. Scroll the page so that the next or previous (depending on `_isBottomOnTouchDevices`) focusable element is positioned behind the navigation bar (but within the viewport).
3. Press (shift) tab  to move focus to the obscured element
4. Confirm that the browser scrolls the focused element into view

Reference:
https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-top