### PR TITLE
Fix: Supplying pluginName on updating menu locking (Fixes #638)

### DIFF
--- a/js/models/menuModel.js
+++ b/js/models/menuModel.js
@@ -20,7 +20,7 @@ class MenuModel extends ContentObjectModel {
   setCustomLocking() {
     const children = this.getAvailableChildModels();
     children.forEach(child => {
-      child.set('_isLocked', this.shouldLock(child));
+      child.set('_isLocked', this.shouldLock(child), { pluginName: 'adapt' });
       if (!(child instanceof MenuModel)) return;
       child.checkLocking();
     });


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Fixes #638 

