### PR TITLE
Fix: Force dialog to close synchronously on page navigation (fixes #648)

### DIFF
--- a/js/drawer.js
+++ b/js/drawer.js
@@ -58,7 +58,7 @@ class Drawer extends Backbone.Controller {
   }
 
   close($toElement = null) {
-    this._drawerView?.hideDrawer($toElement);
+    this._drawerView?.hideDrawer($toElement, { force: true });
   }
 
   remove() {

--- a/js/views/drawerView.js
+++ b/js/views/drawerView.js
@@ -217,19 +217,23 @@ class DrawerView extends Backbone.View {
     this.collection.forEach(model => new DrawerItemView({ model }));
   }
 
-  async hideDrawer($toElement) {
+  async hideDrawer($toElement, {
+    force = false // close the drawer immediately
+  } = {}) {
     if (!this._isVisible) return;
     this._useMenuPosition = false;
 
+    // make sure that the HTMLDialogElement.close in a11y.popupClosed() does not hide the dialog
+    this.$el.css('display', 'block');
     a11y.popupClosed($toElement);
 
     this._isCustomViewVisible = false;
     shadow.hide();
 
     this.$el.addClass('anim-hide-before');
-    await transitionNextFrame();
+    if (!force) await transitionNextFrame();
     this.$el.addClass('anim-hide-after');
-    await transitionsEnded(this.$el);
+    if (!force) await transitionsEnded(this.$el);
 
     this._customView = null;
     $('.js-nav-drawer-btn').attr('aria-expanded', false);
@@ -250,7 +254,7 @@ class DrawerView extends Backbone.View {
   }
 
   remove() {
-    this.hideDrawer();
+    this.hideDrawer(null, { force: true });
     super.remove();
     this.el.removeEventListener('mousedown', this.onShadowClicked, { capture: true });
     $(window).off('keydown', this.onKeyDown);


### PR DESCRIPTION
fixes #648 

Additional fixes to pr https://github.com/adaptlearning/adapt-contrib-core/pull/601
Further fix to https://github.com/adaptlearning/adapt-contrib-core/pull/629

### Fix
* Testing works as expected when dialog is closed immediately on navigation
* Force dialog to remain on screen when `HTMLDialogElement.close()` is called