### PR TITLE
New: Focus at top of page when routing (fixes #626)

### DIFF
--- a/js/a11y.js
+++ b/js/a11y.js
@@ -730,6 +730,12 @@ class A11y extends Backbone.Controller {
   focusFirst($element, options) {
     options = new FocusOptions(options);
     $element = $($element).first();
+    const isBodyFocus = ($element[0] === document.body);
+    if (isBodyFocus) {
+      // force focus to the body, effectively starting the tab cursor from the top
+      this.focus($element, options);
+      return;
+    }
     if (this.isReadable($element)) {
       this.focus($element, options);
       return $element;

--- a/js/a11y.js
+++ b/js/a11y.js
@@ -9,7 +9,7 @@ import FocusOptions from 'core/js/a11y/focusOptions';
 import KeyboardFocusOutline from 'core/js/a11y/keyboardFocusOutline';
 import Log from 'core/js/a11y/log';
 import Scroll from 'core/js/a11y/scroll';
-import TopOfPage from './a11y/topOfPage';
+import TopOfContentObject from './a11y/topOfContentObject';
 import WrapFocus from 'core/js/a11y/wrapFocus';
 import Popup from 'core/js/a11y/popup';
 import defaultAriaLevels from 'core/js/enums/defaultAriaLevels';
@@ -89,7 +89,7 @@ class A11y extends Backbone.Controller {
     this._wrapFocus = new WrapFocus({ a11y: this });
     this._popup = new Popup({ a11y: this });
     this._scroll = new Scroll({ a11y: this });
-    this._topOfPage = new TopOfPage({ a11y: this });
+    this._topOfContentObject = new TopOfContentObject({ a11y: this });
     this._isForcedFocus = false;
     this.log = new Log({ a11y: this });
     deprecated(this);
@@ -762,7 +762,7 @@ class A11y extends Backbone.Controller {
     }
     const isBodyFocus = ($element[0] === document.body);
     if (isBodyFocus) {
-      this._topOfPage.goto();
+      this._topOfContentObject.goto();
       return;
     }
     const perform = () => {

--- a/js/a11y/topOfContentObject.js
+++ b/js/a11y/topOfContentObject.js
@@ -7,10 +7,10 @@ const DEFAULT_TYPE_LABEL = {
 };
 
 /**
- * Add element to focus when entering a new page
+ * Add element to focus when entering a new content object
  * @class
  */
-export default class TopOfPage extends Backbone.Controller {
+export default class TopOfContentObject extends Backbone.Controller {
 
   initialize({ a11y }) {
     this.a11y = a11y;
@@ -24,7 +24,7 @@ export default class TopOfPage extends Backbone.Controller {
   createElement() {
     const config = this.a11y.config;
     if (!config._isEnabled || !config._options._isPopupManagementEnabled) return;
-    this.$element = $('<div id="a11y-topofpage" tabindex="-1" class="visually-hidden"></div>');
+    this.$element = $('<div id="a11y-topofcontentobject" tabindex="-1" class="visually-hidden"></div>');
     this.$body.prepend(this.$element);
   }
 
@@ -33,10 +33,9 @@ export default class TopOfPage extends Backbone.Controller {
     if (!config._isEnabled || !config._options._isPopupManagementEnabled) return;
     const json = location._currentModel.toJSON();
     json._globals = Adapt.course.get('_globals');
-    json.type = json._globals._accessibility._ariaLabels[json._type] ?? DEFAULT_TYPE_LABEL[json._type];
-    json.heading = this.a11y.normalize(Handlebars.templates.heading(json));
+    json.type = this.a11y.normalize(json._globals._accessibility._ariaLabels[json._type] ?? DEFAULT_TYPE_LABEL[json._type]);
     json.displayTitle = this.a11y.normalize(json.displayTitle);
-    const template = Handlebars.compile(json._globals._accessibility._ariaLabels.topOfPage ?? '{{type}} {{displayTitle}}');
+    const template = Handlebars.compile(json._globals._accessibility._ariaLabels.topOfContentObject ?? '{{type}} {{displayTitle}}');
     this.$element.html(template(json));
   }
 

--- a/js/a11y/topOfPage.js
+++ b/js/a11y/topOfPage.js
@@ -35,7 +35,8 @@ export default class TopOfPage extends Backbone.Controller {
   goto() {
     const config = this.a11y.config;
     if (!config._isEnabled || !config._options._isPopupManagementEnabled) return;
-    this.a11y.focus(this.$element, { preventScroll: false, defer: true });
+    if (document.activeElement === this.$element[0]) return;
+    this.$element[0].focus();
   }
 
 }

--- a/js/a11y/topOfPage.js
+++ b/js/a11y/topOfPage.js
@@ -36,7 +36,7 @@ export default class TopOfPage extends Backbone.Controller {
     json.type = json._globals._accessibility._ariaLabels[json._type] || DEFAULT_TYPE_LABEL[json._type];
     json.heading = this.a11y.normalize(Handlebars.templates.heading(json));
     json.displayTitle = this.a11y.normalize(json.displayTitle);
-    const template = Handlebars.compile(json._globals._accessibility._ariaLabels.topOfPage || 'Top of {{type}} {{displayTitle}}');
+    const template = Handlebars.compile(json._globals._accessibility._ariaLabels.topOfPage || '{{type}} {{displayTitle}}');
     this.$element.html(template(json));
   }
 

--- a/js/a11y/topOfPage.js
+++ b/js/a11y/topOfPage.js
@@ -1,0 +1,41 @@
+import Adapt from 'core/js/adapt';
+
+/**
+ * Add element to focus when entering a new page
+ * @class
+ */
+export default class TopOfPage extends Backbone.Controller {
+
+  initialize({ a11y }) {
+    this.a11y = a11y;
+    this.$body = $('body');
+    this.listenTo(Adapt, {
+      'accessibility:ready': this.createElement,
+      'router:location': this.updateElement
+    });
+  }
+
+  createElement() {
+    const config = this.a11y.config;
+    if (!config._isEnabled || !config._options._isPopupManagementEnabled) return;
+    this.$element = $('<div id="a11y-topofpage" tabindex="-1" class="visually-hidden"></div>');
+    this.$body.prepend(this.$element);
+  }
+
+  updateElement(location) {
+    const config = this.a11y.config;
+    if (!config._isEnabled || !config._options._isPopupManagementEnabled) return;
+    const json = location._currentModel.toJSON();
+    json._globals = Adapt.course.get('_globals');
+    json.heading = this.a11y.normalize(Handlebars.templates.heading(json));
+    const template = Handlebars.compile(json._globals._accessibility._ariaLabels.topOfPage || 'Top of page {{a11y.normalize displayTitle}}');
+    this.$element.html(template(json));
+  }
+
+  goto() {
+    const config = this.a11y.config;
+    if (!config._isEnabled || !config._options._isPopupManagementEnabled) return;
+    this.a11y.focus(this.$element, { preventScroll: false, defer: true });
+  }
+
+}

--- a/js/a11y/topOfPage.js
+++ b/js/a11y/topOfPage.js
@@ -1,5 +1,11 @@
 import Adapt from 'core/js/adapt';
 
+const DEFAULT_TYPE_LABEL = {
+  course: 'Main menu',
+  menu: 'Sub menu',
+  page: 'Page'
+};
+
 /**
  * Add element to focus when entering a new page
  * @class
@@ -26,10 +32,8 @@ export default class TopOfPage extends Backbone.Controller {
     const config = this.a11y.config;
     if (!config._isEnabled || !config._options._isPopupManagementEnabled) return;
     const json = location._currentModel.toJSON();
-    json.type = location._currentModel.isTypeGroup('menu')
-      ? 'menu'
-      : 'page';
     json._globals = Adapt.course.get('_globals');
+    json.type = json._globals._accessibility._ariaLabels[json._type] || DEFAULT_TYPE_LABEL[json._type];
     json.heading = this.a11y.normalize(Handlebars.templates.heading(json));
     json.displayTitle = this.a11y.normalize(json.displayTitle);
     const template = Handlebars.compile(json._globals._accessibility._ariaLabels.topOfPage || 'Top of {{type}} {{displayTitle}}');

--- a/js/a11y/topOfPage.js
+++ b/js/a11y/topOfPage.js
@@ -26,9 +26,13 @@ export default class TopOfPage extends Backbone.Controller {
     const config = this.a11y.config;
     if (!config._isEnabled || !config._options._isPopupManagementEnabled) return;
     const json = location._currentModel.toJSON();
+    json.type = location._currentModel.isTypeGroup('menu')
+      ? 'menu'
+      : 'page';
     json._globals = Adapt.course.get('_globals');
     json.heading = this.a11y.normalize(Handlebars.templates.heading(json));
-    const template = Handlebars.compile(json._globals._accessibility._ariaLabels.topOfPage || 'Top of page {{a11y.normalize displayTitle}}');
+    json.displayTitle = this.a11y.normalize(json.displayTitle);
+    const template = Handlebars.compile(json._globals._accessibility._ariaLabels.topOfPage || 'Top of {{type}} {{displayTitle}}');
     this.$element.html(template(json));
   }
 

--- a/js/a11y/topOfPage.js
+++ b/js/a11y/topOfPage.js
@@ -36,7 +36,7 @@ export default class TopOfPage extends Backbone.Controller {
     json.type = json._globals._accessibility._ariaLabels[json._type] || DEFAULT_TYPE_LABEL[json._type];
     json.heading = this.a11y.normalize(Handlebars.templates.heading(json));
     json.displayTitle = this.a11y.normalize(json.displayTitle);
-    const template = Handlebars.compile(json._globals._accessibility._ariaLabels.topOfPage || '{{type}} {{displayTitle}}');
+    const template = Handlebars.compile(json._globals._accessibility._ariaLabels.topOfPage ?? '{{type}} {{displayTitle}}');
     this.$element.html(template(json));
   }
 

--- a/js/a11y/topOfPage.js
+++ b/js/a11y/topOfPage.js
@@ -33,7 +33,7 @@ export default class TopOfPage extends Backbone.Controller {
     if (!config._isEnabled || !config._options._isPopupManagementEnabled) return;
     const json = location._currentModel.toJSON();
     json._globals = Adapt.course.get('_globals');
-    json.type = json._globals._accessibility._ariaLabels[json._type] || DEFAULT_TYPE_LABEL[json._type];
+    json.type = json._globals._accessibility._ariaLabels[json._type] ?? DEFAULT_TYPE_LABEL[json._type];
     json.heading = this.a11y.normalize(Handlebars.templates.heading(json));
     json.displayTitle = this.a11y.normalize(json.displayTitle);
     const template = Handlebars.compile(json._globals._accessibility._ariaLabels.topOfPage ?? '{{type}} {{displayTitle}}');

--- a/less/core/accessibility.less
+++ b/less/core/accessibility.less
@@ -4,30 +4,30 @@
 .block { position: relative; }
 
 // Use to hide content visually while keeping it accessible to assistive technologies
-.visually-hidden {  
-  display: block;  
-  position: absolute !important;  
-  width: 1px !important;  
-  height: 1px !important;  
-  padding: 0 !important;  
-  margin: -1px !important;  
-  overflow: hidden !important;  
-  clip: rect(0, 0, 0, 0) !important;  
-  white-space: nowrap !important;  
-  border: 0 !important;  
+.visually-hidden {
+  display: block;
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
 }
 
-.aria-label {  
-  .visually-hidden();  
-  pointer-events: none;  
-} 
+.aria-label {
+  .visually-hidden();
+  pointer-events: none;
+}
 
 // Use to only display content when it's focused
-.aria-label-focusable, .visually-hidden-focusable {  
-  &:not(:focus):not(:focus-within) {  
-     .visually-hidden;  
-   }  
- } 
+.aria-label-focusable, .visually-hidden-focusable {
+  &:not(:focus):not(:focus-within) {
+     .visually-hidden;
+   }
+ }
 
 // jquery.a11y start
 

--- a/less/core/nav.less
+++ b/less/core/nav.less
@@ -100,12 +100,7 @@ html.is-nav-bottom #wrapper {
       .u-display-none;
     }
 
-    &:not(:focus-visible) {
-      height: 0;
-      padding: 0;
-      margin: 0;
-      overflow: hidden;
-    }
+    .visually-hidden-focusable()
   }
 
   &__back-btn .icon {

--- a/schema/course.model.schema
+++ b/schema/course.model.schema
@@ -354,6 +354,38 @@
                   "inputType": "Text",
                   "required": true,
                   "translatable": true
+                },
+                "topOfContentObject": {
+                  "type": "string",
+                  "title": "",
+                  "default": "{{type}} {{displayTitle}}",
+                  "inputType": "Text",
+                  "required": true,
+                  "translatable": true
+                },
+                "course": {
+                  "type": "string",
+                  "title": "",
+                  "default": "Main menu",
+                  "inputType": "Text",
+                  "required": true,
+                  "translatable": true
+                },
+                "menu": {
+                  "type": "string",
+                  "title": "",
+                  "default": "Sub menu",
+                  "inputType": "Text",
+                  "required": true,
+                  "translatable": true
+                },
+                "page": {
+                  "type": "string",
+                  "title": "",
+                  "default": "Page",
+                  "inputType": "Text",
+                  "required": true,
+                  "translatable": true
                 }
               }
             },

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -316,6 +316,38 @@
                       "_adapt": {
                         "translatable": true
                       }
+                    },
+                    "topOfContentObject": {
+                      "type": "string",
+                      "title": "Top of content object",
+                      "default": "{{type}} {{displayTitle}}",
+                      "_adapt": {
+                        "translatable": true
+                      }
+                    },
+                    "course": {
+                      "type": "string",
+                      "title": "Main menu",
+                      "default": "Main menu",
+                      "_adapt": {
+                        "translatable": true
+                      }
+                    },
+                    "menu": {
+                      "type": "string",
+                      "title": "Sub menu",
+                      "default": "Sub menu",
+                      "_adapt": {
+                        "translatable": true
+                      }
+                    },
+                    "page": {
+                      "type": "string",
+                      "title": "Page",
+                      "default": "Page",
+                      "_adapt": {
+                        "translatable": true
+                      }
                     }
                   }
                 },


### PR DESCRIPTION
fixes #626 
a working alternative to #627 

Notifies the screen reader that a new content object is loaded, allows tabbing and arrowing forward onto the skip navigation button as well as scrolling with the arrow keys without a screen reader. Text is configurable at `_globals._accessibility._ariaLabels.topOfContentObject = '{{type}} {{displayTitle}}'`

`{{type}}` is `Main menu`, `Sub menu` or `Page`
`{{displayTitle}}` is the normalized `displayTitle`

Types are translatable at:
`_globals._accessibility._ariaLabels.course = "Main menu"`
`_globals._accessibility._ariaLabels.menu = "Sub menu"`
`_globals._accessibility._ariaLabels.page = "Page"`

### New
* Added topOfContentObject functionality which inserts an element at the top of the page, the element is updated and focused when routing

### Tested
I have done:

* voiceover with safari and chrome on macos 
* firefox and chrome and edge on windows with nvda and jaws
* android with chrome and talkback

All seem to read correctly, and it seems to make navigating the different content objects much more precise. There are the occasional double reads of `Page Presentation components` or `Main menu Adapt Version 5`  with jaws in firefox and edge, but most of the time they all behave nicely.

