### PR TITLE
Fix: Fix drawer overflow issue with scrolling(fixes #659)

### DIFF
--- a/less/core/drawer.less
+++ b/less/core/drawer.less
@@ -5,6 +5,7 @@
   // Update animation to be css rather than js
   height: 100%;
   width: @drawer-width;
+  overflow: hidden;
   z-index: 100;
 
   &.is-position-auto,


### PR DESCRIPTION
Fix #659 

### Fix
* Prevent `.drawer` from scrolling. Instead, we will rely on `.drawer__holder` for the scrolling container.

### Testing
1. Install `adapt-contrib-glossary`
2. Add a large amount of glossary items (30+)
3. Scroll down to the end of the list. Ensure that you cannot scroll past the last item.