### PR TITLE
Update: Replace dialog button aria-expanded with aria-haspopup dialog (fixes #657)

### DIFF
--- a/js/views/drawerView.js
+++ b/js/views/drawerView.js
@@ -26,8 +26,7 @@ class DrawerView extends Backbone.View {
     return {
       'aria-modal': 'true',
       'aria-labelledby': 'drawer-heading',
-      'aria-hidden': 'true',
-      'aria-expanded': 'false'
+      'aria-hidden': 'true'
     };
   }
 
@@ -159,8 +158,7 @@ class DrawerView extends Backbone.View {
     this.setDrawerPosition(position);
     this.$el
       .removeClass('u-display-none')
-      .attr('aria-hidden', 'false')
-      .attr('aria-expanded', 'true');
+      .attr('aria-hidden', 'false');
     // Only trigger popup:opened if drawer is visible, pass popup manager drawer element
     if (!this._isVisible) {
       a11y.popupOpened(this.$el);
@@ -192,7 +190,6 @@ class DrawerView extends Backbone.View {
     }
 
     $('.js-drawer-holder').scrollTop(0);
-    $('.js-nav-drawer-btn').attr('aria-expanded', true);
     Adapt.trigger('drawer:opened');
 
     this.$el.addClass('anim-show-before');
@@ -236,7 +233,6 @@ class DrawerView extends Backbone.View {
     if (!force) await transitionsEnded(this.$el);
 
     this._customView = null;
-    $('.js-nav-drawer-btn').attr('aria-expanded', false);
     Adapt.trigger('drawer:closed');
 
     this._isVisible = false;
@@ -248,8 +244,7 @@ class DrawerView extends Backbone.View {
     this.$el
       .removeAttr('style')
       .addClass('u-display-none')
-      .attr('aria-hidden', 'true')
-      .attr('aria-expanded', 'false');
+      .attr('aria-hidden', 'true');
     this.setDrawerPosition(this._globalDrawerPosition);
   }
 

--- a/js/views/navigationView.js
+++ b/js/views/navigationView.js
@@ -119,8 +119,7 @@ class NavigationView extends Backbone.View {
       const shouldIgnore = changes.every(([key]) => [
         'attributes.data-a11y-force-focus',
         'attributes.tabindex',
-        'attributes.aria-hidden',
-        'attributes.aria-expanded'
+        'attributes.aria-hidden'
       ].includes(key));
       if (shouldIgnore) return;
     }

--- a/templates/nav.hbs
+++ b/templates/nav.hbs
@@ -20,7 +20,7 @@
     <div class="nav__spacer" aria-hidden="true" data-order="{{_navOrder}}"></div>
   {{/each}}
 
-  <button name="drawer" class="btn-icon nav__btn nav__drawer-btn js-nav-drawer-btn is-position-{{#if _config._drawer._position}}{{_config._drawer._position}}{{else}}auto{{/if}}" data-event="toggleDrawer" aria-expanded="false" aria-label="{{_globals._accessibility._ariaLabels.navigationDrawer}}" data-order="{{_globals._extensions._drawer._navOrder}}" data-tooltip-id="drawer">
+  <button name="drawer" class="btn-icon nav__btn nav__drawer-btn js-nav-drawer-btn is-position-{{#if _config._drawer._position}}{{_config._drawer._position}}{{else}}auto{{/if}}" data-event="toggleDrawer" aria-haspopup="dialog" aria-label="{{_globals._accessibility._ariaLabels.navigationDrawer}}" data-order="{{_globals._extensions._drawer._navOrder}}" data-tooltip-id="drawer">
     <span class="icon {{#if _config._drawer._iconClass}}{{_config._drawer._iconClass}}{{else}}icon-list{{/if}}" aria-hidden="true"></span>
     {{#if Adapt.course._navigation._showLabel}}
     <span class='nav__btn-label' aria-hidden="true">{{_globals._accessibility._ariaLabels.navigationDrawer}}</span>


### PR DESCRIPTION
### Update
- For navigation buttons that trigger a dialog to open (Notify popup or Drawer), the button `aria-expanded` has been replaced with `aria-haspopup="dialog"`.  Please refer to the [issue](https://github.com/adaptlearning/adapt-contrib-core/issues/657) for the research and discussion supporting this change. 
Fixes https://github.com/adaptlearning/adapt-contrib-core/issues/657

- Remove `aria-expanded` from Drawer `<dialog>` as this serves no purpose and it is not the intended use. See [MDN note](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-expanded#:~:text=When%20the%20popup%20element%20is,should%20be%20set%20to%20true%20.&text=Note%3A%20The%20presence%20of%20the,expanded%20state%20of%20other%20elements) for reference below or refer to the [issue](https://github.com/adaptlearning/adapt-contrib-core/issues/658) description.
Fixes https://github.com/adaptlearning/adapt-contrib-core/issues/658

### Testing
Navigate to the Resources button in the nav bar using a screen reader. Depending on the browser/screen reader used, expect the following reading....

VoiceOver “Open course resources, dialog pop-up, button”
NVDA “Open course resources, button opens dialog”
JAWS “Open course resources, button has popup dialog”

Tested with the following combinations:
VoiceOver Safari macOS and iPhone
VoiceOver Chrome and Firefox macOS
JAWS Chrome, Edge and Firefox Windows
NVDA Chrome, Edge and Firefox Windows

### Related PRs
Other navigation plugins that include `aria-expanded` for buttons that open Drawer or Notify popup dialogs will also need updating. Please see summary below.

- [Resources](https://github.com/adaptlearning/adapt-contrib-resources) and [Glossary](https://github.com/adaptlearning/adapt-contrib-glossary) have been addressed with this PR.

- PLP PR - https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/pull/251

- Visua11y PR- https://github.com/cgkineo/adapt-visua11y/pull/130




