### PR TITLE
Update: Remove drawer dialog modal aria-expanded state (fixes #658)

### DIFF
--- a/js/views/drawerView.js
+++ b/js/views/drawerView.js
@@ -26,8 +26,7 @@ class DrawerView extends Backbone.View {
     return {
       'aria-modal': 'true',
       'aria-labelledby': 'drawer-heading',
-      'aria-hidden': 'true',
-      'aria-expanded': 'false'
+      'aria-hidden': 'true'
     };
   }
 
@@ -159,8 +158,7 @@ class DrawerView extends Backbone.View {
     this.setDrawerPosition(position);
     this.$el
       .removeClass('u-display-none')
-      .attr('aria-hidden', 'false')
-      .attr('aria-expanded', 'true');
+      .attr('aria-hidden', 'false');
     // Only trigger popup:opened if drawer is visible, pass popup manager drawer element
     if (!this._isVisible) {
       a11y.popupOpened(this.$el);
@@ -248,8 +246,7 @@ class DrawerView extends Backbone.View {
     this.$el
       .removeAttr('style')
       .addClass('u-display-none')
-      .attr('aria-hidden', 'true')
-      .attr('aria-expanded', 'false');
+      .attr('aria-hidden', 'true');
     this.setDrawerPosition(this._globalDrawerPosition);
   }
 


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-core/issues/658

### Update
- Remove `aria-expanded` from Drawer `<dialog>` as this serves no purpose and it is not the intended use. 

When testing with a screen reader, the 'expanded' state wasn't announced so removing this doesn't have an impact on the reading however updating inline with accessibility best practice. See [MDN note](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-expanded#:~:text=When%20the%20popup%20element%20is,should%20be%20set%20to%20true%20.&text=Note%3A%20The%20presence%20of%20the,expanded%20state%20of%20other%20elements) for reference below or refer to the [issue](https://github.com/adaptlearning/adapt-contrib-core/issues/658) description.

> Note: The presence of the aria-expanded attribute indicates control. Avoid including it on elements that do not control the expanded state of other elements.







