### PR TITLE
New: contextActivities API for adding context to questions for reporting purposes

### DIFF
--- a/js/enums/completionStateEnum.js
+++ b/js/enums/completionStateEnum.js
@@ -3,7 +3,8 @@ const COMPLETION_STATE = ENUM([
   'INCOMPLETE',
   'COMPLETED',
   'PASSED',
-  'FAILED'
+  'FAILED',
+  'UNKNOWN'
 ]);
 
 export default COMPLETION_STATE;

--- a/js/models/questionModel.js
+++ b/js/models/questionModel.js
@@ -443,20 +443,20 @@ class QuestionModel extends ComponentModel {
       type,
       title
     };
-    const index = this._contextActivities.findIndex(activity => activity.id === id);
+    const index = this.contextActivities.findIndex(activity => activity.id === id);
     const isIncluded = index !== -1;
     if (isIncluded) {
-      this._contextActivities[index] = entry;
+      this.contextActivities[index] = entry;
       return;
     }
-    this._contextActivities.push(entry);
+    this.contextActivities.push(entry);
   }
 
   /**
    * Returns the `ContextActivity` collection for the question
    * @returns {ContextActivity[]}
    */
-  getContextActivities() {
+  get contextActivities() {
     return this._contextActivities;
   }
 

--- a/js/models/questionModel.js
+++ b/js/models/questionModel.js
@@ -2,6 +2,12 @@ import Adapt from 'core/js/adapt';
 import components from 'core/js/components';
 import ComponentModel from 'core/js/models/componentModel';
 import BUTTON_STATE from 'core/js/enums/buttonStateEnum';
+/**
+ * @typedef {Object} ContextActivity
+ * @property {string} id
+ * @property {string} type
+ * @property {string} title
+ */
 
 class QuestionModel extends ComponentModel {
 
@@ -65,6 +71,7 @@ class QuestionModel extends ComponentModel {
   }
 
   init() {
+    /** @type {ContextActivity[]} */
     this._contextActivities = [];
     this.setupDefaultSettings();
     this.updateRawScore();
@@ -408,9 +415,13 @@ class QuestionModel extends ComponentModel {
     return {};
   }
 
+  /**
+   * Add a `ContextActivity` for the content object ancestors assocaited with the question
+   */
   addContentObjectContextActivities() {
     // SCORM doesn't necessarily need course context as implied in reports (exclude via spoor)
     this.getAncestorModels()
+      .reverse()
       .filter(model => model.isTypeGroup('contentobject'))
       .forEach(model => {
         const id = model.get('_id');
@@ -420,16 +431,31 @@ class QuestionModel extends ComponentModel {
       });
   }
 
+  /**
+   * Add a `ContextActivity` to the collection
+   * @param {string} id
+   * @param {string} type
+   * @param {string} title
+   */
   addContextActivity(id, type, title) {
-    const isIncluded = this._contextActivities.some(activity => activity.id === id);
-    if (isIncluded) return;
-    this._contextActivities.push({
+    const entry = {
       id,
       type,
       title
-    });
+    };
+    const index = this._contextActivities.findIndex(activity => activity.id === id);
+    const isIncluded = index !== -1;
+    if (isIncluded) {
+      this._contextActivities[index] = entry;
+      return;
+    }
+    this._contextActivities.push(entry);
   }
 
+  /**
+   * Returns the `ContextActivity` collection for the question
+   * @returns ContextActivity[]
+   */
   getContextActivities() {
     return this._contextActivities;
   }

--- a/js/models/questionModel.js
+++ b/js/models/questionModel.js
@@ -454,7 +454,7 @@ class QuestionModel extends ComponentModel {
 
   /**
    * Returns the `ContextActivity` collection for the question
-   * @returns ContextActivity[]
+   * @returns {ContextActivity[]}
    */
   getContextActivities() {
     return this._contextActivities;

--- a/js/models/questionModel.js
+++ b/js/models/questionModel.js
@@ -65,6 +65,7 @@ class QuestionModel extends ComponentModel {
   }
 
   init() {
+    this._contextActivities = [];
     this.setupDefaultSettings();
     this.updateRawScore();
     super.init();
@@ -359,6 +360,7 @@ class QuestionModel extends ComponentModel {
       _buttonState: BUTTON_STATE.SUBMIT,
       _shouldShowMarking: this.shouldShowMarking
     });
+    this._contextActivities = [];
     return true;
   }
 
@@ -406,6 +408,32 @@ class QuestionModel extends ComponentModel {
     return {};
   }
 
+  addContentObjectContextActivities() {
+    // SCORM doesn't necessarily need course context as implied in reports (exclude via spoor)
+    this.getAncestorModels()
+      .filter(model => model.isTypeGroup('contentobject'))
+      .forEach(model => {
+        const id = model.get('_id');
+        const type = model.get('_type');
+        const title = model.get('title') || model.get('displayTitle');
+        this.addContextActivity(id, type, title);
+      });
+  }
+
+  addContextActivity(id, type, title) {
+    const isIncluded = this._contextActivities.some(activity => activity.id === id);
+    if (isIncluded) return;
+    this._contextActivities.push({
+      id,
+      type,
+      title
+    });
+  }
+
+  getContextActivities() {
+    return this._contextActivities;
+  }
+
   // Returns a string detailing how the user answered the question.
   getResponse() {}
 
@@ -419,6 +447,7 @@ class QuestionModel extends ComponentModel {
     // Stores the current attempt state
     if (this.get('_shouldStoreAttempts')) this.addAttemptObject();
     this.set('_shouldShowMarking', this.shouldShowMarking);
+    this.addContentObjectContextActivities();
   }
 
   /** @type {boolean} */

--- a/js/views/questionView.js
+++ b/js/views/questionView.js
@@ -211,8 +211,6 @@ class QuestionView extends ComponentView {
       this.showMarking();
     }
 
-    this.recordInteraction();
-
     // Used to setup the feedback by checking against
     // question isCorrect or isPartlyCorrect
     this._runModelCompatibleFunction('setupFeedback');
@@ -236,6 +234,8 @@ class QuestionView extends ComponentView {
     this.model.onSubmitted();
     this.onSubmitted();
     Adapt.trigger('questionView:submitted', this);
+
+    this.recordInteraction();
   }
 
   showInstructionError() {


### PR DESCRIPTION
Fixes #669.

### New
* Added contextActivities API for adding context to questions for reporting purposes
  * xAPI and SCORM handle this differently so their relevant plugins can choose to use and expand on the base data as required for each spec
* Added `UNKNOWN` to https://github.com/adaptlearning/adapt-contrib-core/blob/master/js/enums/completionStateEnum.js