### PR TITLE
Fix: Add end margin only when question is complete (fix #650)

### DIFF
--- a/less/core/button.less
+++ b/less/core/button.less
@@ -33,8 +33,8 @@
     width: 100%;
   }
 
-  .can-show-marking &__action.is-full-width,
-  .can-show-marking &__feedback.is-full-width {
+  .can-show-marking.is-complete &__action.is-full-width,
+  .can-show-marking.is-complete &__feedback.is-full-width {
     margin-inline-end: @icon-size + (@item-margin * 2);
   }
 


### PR DESCRIPTION
Fix #650 

### Fix
* Adds end margin only when question is complete

### Related
* Needs this Vanilla theme PR approved as well: https://github.com/adaptlearning/adapt-contrib-vanilla/pull/559