### PR TITLE
New: Add ability for question models to specify a buttons template (fix #692)

### DIFF
--- a/js/views/buttonsView.js
+++ b/js/views/buttonsView.js
@@ -38,7 +38,7 @@ export default class ButtonsView extends Backbone.View {
 
   render() {
     const data = this.model.toJSON();
-    const template = Handlebars.templates.buttons;
+    const template = Handlebars.templates[data._buttonsTemplate || 'buttons'];
     _.defer(() => {
       this.postRender();
       Adapt.trigger('buttonsView:postRender', this);


### PR DESCRIPTION
Fix #692 

### New
* Add ability for question models to specific a Handlebars `.hbs` buttons template

### Testing
1. In a question model, set the `_buttonsTemplate` property to `customButtons`.
2. In the question plugin's templates folder, add a template called _customButtons.hbs_. The contents should roughly resemble the core buttons template at _src/core/templates/buttons.hbs_.
3. Add some testing content in _customButtons.hbs_ so that you can tell that it is being used instead of the core template.

