### PR TITLE
Fix: Manage focus to prevent jaws virtual cursor from scrolling (#695)

### DIFF
--- a/js/a11y.js
+++ b/js/a11y.js
@@ -185,6 +185,10 @@ class A11y extends Backbone.Controller {
     return Date.now() - this._lastFocusTime;
   }
 
+  get currentActiveElement() {
+    return this._activeElements[0];
+  }
+
   get previousActiveElement() {
     return this._activeElements[1];
   }

--- a/js/a11y/browserFocus.js
+++ b/js/a11y/browserFocus.js
@@ -74,6 +74,9 @@ export default class BrowserFocus extends Backbone.Controller {
     const $stack = $([...$element.toArray(), ...$element.parents().toArray()]);
     const $focusable = $stack.filter(config._options._tabbableElements);
     if (!$focusable.length) {
+      const element = this.a11y.currentActiveElement;
+      // refocus on the existing active element to stop jaws from scrolling
+      element?.focus();
       return;
     }
     const $closestFocusable = $element.closest(config._options._tabbableElements);

--- a/js/fixes/safari.label.click.blur.js
+++ b/js/fixes/safari.label.click.blur.js
@@ -1,5 +1,6 @@
 import Adapt from 'core/js/adapt';
 import 'core/js/templates';
+import ItemModel from '../models/itemModel';
 
 /**
   In Safari, a click triggers a mousedown, a blur, a mouseup, a focus, then a click,
@@ -25,6 +26,8 @@ function onLabelClick (event) {
   const input = document.querySelector(`[id="${event.currentTarget.getAttribute('for')}"]`);
   if (!input) return;
   event.preventDefault();
+  // focus first so that jaws doesn't jump scroll to the top
+  input.focus();
   input.click();
 };
 


### PR DESCRIPTION
fixes #695 

### Fix
* Ensure safari label+input label click correctly focuses on input

### Update
* Refocus on the existing active element when a non-interactive element is clicked

### New
* Added `a11y.currentActiveElement`



