### PR TITLE
Fix: Remove outdated Firefox outline styles (fix #702)

### DIFF
--- a/less/_browser/normalize.less
+++ b/less/_browser/normalize.less
@@ -212,17 +212,6 @@ button::-moz-focus-inner,
 }
 
 /**
- * Restore the focus styles unset by the previous rule.
- */
-
-button:-moz-focusring,
-[type="button"]:-moz-focusring,
-[type="reset"]:-moz-focusring,
-[type="submit"]:-moz-focusring {
-  outline: 1px dotted ButtonText;
-}
-
-/**
  * Correct the padding in Firefox.
  */
 


### PR DESCRIPTION
Fix #702 

### Fix
* Remove outdated outline styles for Firefox so that default browser styles can be used.

### Testing
In Firefox, navigate to an enabled Submit button via keyboard navigation. Outline styles should resemble unaltered, browser default outline styles for focusing.

