### PR TITLE
Fix: Defer data-ready events

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -88,7 +88,7 @@ class Data extends AdaptCollection {
     if (Adapt.get('_isStarted')) {
       Adapt.set('_isStarted', false);
     }
-    this.loadCourseData(language, previousLanguage);
+    await this.loadCourseData(language, previousLanguage);
   }
 
   async loadCourseData(newLanguage, previousLanguage) {
@@ -188,6 +188,7 @@ class Data extends AdaptCollection {
     try {
       // Setup the newly added models
       this.forEach(model => model.setupModel?.());
+      await wait.queue();
       Adapt.trigger('app:dataLoaded');
     } catch (e) {
       logging.error('Error during app:dataLoading trigger', e);


### PR DESCRIPTION
When switching language or reloading a course, plugins like trickle, page-level progress, and assessment sometimes run before the course models are fully built. This causes runtime errors (e.g., `findDescendantModels is not a function`) because plugins try to use incomplete model objects.

Originally reported here: https://github.com/adaptlearning/adapt-contrib-languagePicker/issues/120

[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
- Possibly fixes #698 & #705 
- Added `await wait.queue()` after `setupModel()` in `triggerDataLoaded()` so all models finish building before firing `app:dataLoaded`
- Removed duplicate event triggers in `onLanguageChange()`; now only triggered after models are ready

[//]: # (List appropriate steps for testing if needed)
### Testing
You might not be able to replicate with a vanilla install of Adapt. I'm guessing it needs a wealth of content & features in it to replicate. Alas, this is how race conditions go. :(
1. Open a course with multiple languages
2. Progress to content using trickle, page-level progress, or assessment
3. Switch languages or reload the page mid-course
4. Check the browser console for errors
5. Confirm all plugins work as expected after switching or reloading

### Additional notes
This update makes sure plugins only run after all models are ready, preventing errors and improving reliability during language changes or reloads.

