### PR TITLE
Fix: Remove moz-focus-inner styles from normalize (fix #704)

### DIFF
--- a/less/_browser/normalize.less
+++ b/less/_browser/normalize.less
@@ -200,18 +200,6 @@ button,
 }
 
 /**
- * Remove the inner border and padding in Firefox.
- */
-
-button::-moz-focus-inner,
-[type="button"]::-moz-focus-inner,
-[type="reset"]::-moz-focus-inner,
-[type="submit"]::-moz-focus-inner {
-  border-style: none;
-  padding: 0;
-}
-
-/**
  * Correct the padding in Firefox.
  */
 


### PR DESCRIPTION
Fix #704 

### Fix
* Removes deprecated `-moz-focus-inner` styles. The pseudo-element is [deprecated](https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-focus-inner) and no longer supported by modern versions of Firefox. So, it should be safe to remove and should not cause any side effects.