### PR TITLE
Update: JSDoc documentation for drawer system (fixes #812)

### DIFF
--- a/js/drawer.js
+++ b/js/drawer.js
@@ -44,6 +44,14 @@ import tooltips from './tooltips';
 const DrawerCollection = new Backbone.Collection(null, { comparator: 'drawerOrder' });
 
 /**
+ * @typedef {Object} DrawerItemConfig
+ * @property {string} title - Display title for the drawer item
+ * @property {string} description - Description text shown below title
+ * @property {string} [className] - CSS class name for custom styling
+ * @property {number} [drawerOrder=0] - Sort order (lower numbers appear first)
+ */
+
+/**
  * @class Drawer
  * @classdesc Singleton service managing drawer sidebar. Only one instance exists per course.
  * @extends {Backbone.Controller}
@@ -131,11 +139,7 @@ class Drawer extends Backbone.Controller {
   /**
    * Registers a drawer item.
    * Replaces existing item with same eventCallback.
-   * @param {Object} drawerObject - Drawer item configuration
-   * @param {string} drawerObject.title - Display title
-   * @param {string} drawerObject.description - Description text
-   * @param {string} [drawerObject.className] - CSS class for styling
-   * @param {number} [drawerObject.drawerOrder=0] - Sort order (lower numbers first)
+   * @param {DrawerItemConfig} drawerObject - Drawer item configuration
    * @param {string} eventCallback - Event name to trigger when clicked
    * @example
    * drawer.addItem({

--- a/js/drawer.js
+++ b/js/drawer.js
@@ -87,7 +87,7 @@ class Drawer extends Backbone.Controller {
    * @returns {boolean} True if drawer is visible showing drawer
    * @example
    * if (drawer.isOpen) {
-   *   console.log('Drawer is showing');
+   *   return;
    * }
    */
   get isOpen() {

--- a/js/drawer.js
+++ b/js/drawer.js
@@ -1,3 +1,49 @@
+/**
+ * @file Drawer Service - Sidebar navigation system with menu items and custom views
+ * @module core/js/drawer
+ * @description Singleton service managing the drawer sidebar navigation system. Provides API
+ * for registering menu items and displaying custom views. Handles drawer lifecycle, state management,
+ * and integration with navigation toolbar.
+ *
+ * **Architecture:**
+ * - Singleton controller (exported as instance)
+ * - Manages {@link DrawerCollection} of menu items (sorted by drawerOrder)
+ * - Creates/destroys {@link DrawerView} on language change
+ * - Two operational modes: menu list or custom view
+ *
+ * **Public Events Triggered:**
+ * - `drawer:opened` - Drawer opened (any mode)
+ * - `drawer:openedItemView` - Menu mode shown
+ * - `drawer:openedCustomView` - Custom view shown
+ * - `drawer:closed` - Drawer closed
+ * - `drawer:empty` - Drawer content cleared
+ * - `drawer:noItems` - No menu items registered
+ *
+ * **Usage Pattern:**
+ * ```javascript
+ * // Register menu item
+ * drawer.addItem({
+ *   title: 'Resources',
+ *   description: 'View course resources',
+ *   className: 'resources-drawer-item',
+ *   drawerOrder: 10
+ * }, 'resources:showDrawer');
+ *
+ * // Listen for callback
+ * Adapt.on('resources:showDrawer', () => {
+ *   drawer.openCustomView(new ResourcesView());
+ * });
+ * ```
+ *
+ * **Known Issues & Improvements:**
+ * - **Issue:** DrawerCollection is module-scoped but not accessible via API
+ * - **Issue:** No way to update existing item without remove/add
+ * - **Issue:** No validation of drawerObject structure
+ * - **Enhancement:** Add `updateItem(eventCallback, drawerObject)` method
+ * - **Enhancement:** Add `getItem(eventCallback)` to retrieve item data
+ * - **Enhancement:** Add `getAllItems()` to get current menu items
+ */
+
 import Backbone from 'backbone';
 import Adapt from 'core/js/adapt';
 import DrawerView from 'core/js/views/drawerView';
@@ -5,6 +51,11 @@ import tooltips from './tooltips';
 
 const DrawerCollection = new Backbone.Collection(null, { comparator: 'drawerOrder' });
 
+/**
+ * @class Drawer
+ * @classdesc Singleton service for drawer navigation system. Only one instance exists per course.
+ * @extends {Backbone.Controller}
+ */
 class Drawer extends Backbone.Controller {
 
   initialize() {
@@ -29,22 +80,85 @@ class Drawer extends Backbone.Controller {
     this.remove();
   }
 
+  /**
+   * Toggles drawer open/closed based on current state.
+   * Convenience method for open/close logic.
+   * @example
+   * Adapt.trigger('navigation:toggleDrawer');
+   *
+   * drawer.toggle();
+   */
   toggle() {
     (this.isOpen) ? this.close() : this.open();
   }
 
+  /**
+   * Checks if drawer is currently open in menu mode.
+   * Returns false if drawer is showing custom view or closed.
+   * @returns {boolean} True if drawer is visible in menu mode
+   * @example
+   * if (drawer.isOpen) {
+   *   console.log('Menu is showing');
+   * }
+   */
   get isOpen() {
     return this._drawerView?.isOpen ?? false;
   }
 
+  /**
+   * Opens drawer in menu mode showing list of registered items.
+   * If only one item registered, automatically triggers its callback.
+   * @fires drawer:opened
+   * @fires drawer:openedItemView
+   * @example
+   * drawer.open();
+   */
   open() {
     this._drawerView?.showDrawer(true);
   }
 
+  /**
+   * Opens drawer with custom view content.
+   * Called by plugins in response to menu item click.
+   * @param {Backbone.View|jQuery|HTMLElement|string} view - View instance or HTML content to display
+   * @param {boolean} [hasBackButton=true] - Show back button to return to menu
+   * @param {string} [position] - Override drawer position ('left'|'right', null uses global config)
+   * @fires drawer:opened
+   * @fires drawer:openedCustomView
+   * @fires drawer:empty
+   * @example
+   * Adapt.on('resources:showDrawer', () => {
+   *   const resourcesView = new ResourcesView();
+   *   drawer.openCustomView(resourcesView, true, 'right');
+   * });
+   *
+   * drawer.openCustomView('<div>Simple HTML</div>', false);
+   */
   openCustomView(view, hasBackButton, position) {
     this._drawerView?.openCustomView(view, hasBackButton, position);
   }
 
+  /**
+   * Registers a menu item in the drawer.
+   * Replaces existing item with same eventCallback.
+   * @param {Object} drawerObject - Menu item configuration
+   * @param {string} drawerObject.title - Display title
+   * @param {string} drawerObject.description - Description text
+   * @param {string} [drawerObject.className] - CSS class for styling
+   * @param {number} [drawerObject.drawerOrder=0] - Sort order (lower numbers first)
+   * @param {string} eventCallback - Event name to trigger when clicked
+   * @example
+   * drawer.addItem({
+   *   title: 'Resources',
+   *   description: 'View downloadable resources',
+   *   className: 'resources-item',
+   *   drawerOrder: 20
+   * }, 'resources:showDrawer');
+   *
+   * Adapt.on('resources:showDrawer', () => {
+   *   drawer.openCustomView(new ResourcesView());
+   * });
+   */
   addItem(drawerObject, eventCallback) {
     if (this.hasItem(eventCallback)) {
       DrawerCollection.remove(DrawerCollection.find(item => item.eventCallback === eventCallback));
@@ -53,14 +167,40 @@ class Drawer extends Backbone.Controller {
     DrawerCollection.add(drawerObject);
   }
 
+  /**
+   * Checks if menu item is registered.
+   * @param {string} eventCallback - Event callback to check
+   * @returns {boolean} True if item exists
+   * @example
+   * if (!drawer.hasItem('resources:showDrawer')) {
+   *   drawer.addItem({ title: 'Resources' }, 'resources:showDrawer');
+   * }
+   */
   hasItem(eventCallback) {
     return Boolean(DrawerCollection.find(item => item.eventCallback === eventCallback));
   }
 
+  /**
+   * Closes the drawer immediately.
+   * Called automatically on navigation.
+   * @param {jQuery} [$toElement=null] - Element to focus after closing
+   * @fires drawer:closed
+   * @example
+   * drawer.close();
+   *
+   * drawer.close($('.js-nav-home-btn'));
+   */
   close($toElement = null) {
     this._drawerView?.hideDrawer($toElement, { force: true });
   }
 
+  /**
+   * Destroys the drawer view and cleans up.
+   * Called automatically on language change.
+   * @fires drawer:empty
+   * @example
+   * drawer.remove();
+   */
   remove() {
     this._drawerView?.remove();
     this._drawerView = null;

--- a/js/drawer.js
+++ b/js/drawer.js
@@ -1,27 +1,28 @@
 /**
- * @file Drawer Service - Sidebar navigation system with menu items and custom views
+ * @file Drawer Service - Sidebar with drawer items and custom views
  * @module core/js/drawer
- * @description Singleton service managing the drawer sidebar navigation system. Provides API
- * for registering menu items and displaying custom views. Handles drawer lifecycle, state management,
- * and integration with navigation toolbar.
+ * @description Singleton service managing the drawer sidebar. Provides API
+ * for registering drawer items and displaying custom views. Handles drawer lifecycle, state management,
+ * and integration with toolbar.
  *
  * **Architecture:**
  * - Singleton controller (exported as instance)
- * - Manages {@link DrawerCollection} of menu items (sorted by drawerOrder)
+ * - Manages {@link DrawerCollection} of drawer items (sorted by drawerOrder)
  * - Creates/destroys {@link DrawerView} on language change
- * - Two operational modes: menu list or custom view
+ * - Two operational modes: drawer list or custom view
  *
  * **Public Events Triggered:**
  * - `drawer:opened` - Drawer opened (any mode)
- * - `drawer:openedItemView` - Menu mode shown
+ * - `drawer:openedItemView` - Drawer shown
  * - `drawer:openedCustomView` - Custom view shown
  * - `drawer:closed` - Drawer closed
  * - `drawer:empty` - Drawer content cleared
- * - `drawer:noItems` - No menu items registered
+ * - `drawer:noItems` - No drawer items registered
  *
- * **Usage Pattern:**
- * ```javascript
- * // Register menu item
+ * @example
+ * import drawer from 'core/js/drawer';
+ *
+ * // Register drawer item
  * drawer.addItem({
  *   title: 'Resources',
  *   description: 'View course resources',
@@ -33,15 +34,6 @@
  * Adapt.on('resources:showDrawer', () => {
  *   drawer.openCustomView(new ResourcesView());
  * });
- * ```
- *
- * **Known Issues & Improvements:**
- * - **Issue:** DrawerCollection is module-scoped but not accessible via API
- * - **Issue:** No way to update existing item without remove/add
- * - **Issue:** No validation of drawerObject structure
- * - **Enhancement:** Add `updateItem(eventCallback, drawerObject)` method
- * - **Enhancement:** Add `getItem(eventCallback)` to retrieve item data
- * - **Enhancement:** Add `getAllItems()` to get current menu items
  */
 
 import Backbone from 'backbone';
@@ -53,7 +45,7 @@ const DrawerCollection = new Backbone.Collection(null, { comparator: 'drawerOrde
 
 /**
  * @class Drawer
- * @classdesc Singleton service for drawer navigation system. Only one instance exists per course.
+ * @classdesc Singleton service managing drawer sidebar. Only one instance exists per course.
  * @extends {Backbone.Controller}
  */
 class Drawer extends Backbone.Controller {
@@ -82,10 +74,7 @@ class Drawer extends Backbone.Controller {
 
   /**
    * Toggles drawer open/closed based on current state.
-   * Convenience method for open/close logic.
    * @example
-   * Adapt.trigger('navigation:toggleDrawer');
-   *
    * drawer.toggle();
    */
   toggle() {
@@ -93,12 +82,12 @@ class Drawer extends Backbone.Controller {
   }
 
   /**
-   * Checks if drawer is currently open in menu mode.
+   * Checks if drawer is currently open showing drawer.
    * Returns false if drawer is showing custom view or closed.
-   * @returns {boolean} True if drawer is visible in menu mode
+   * @returns {boolean} True if drawer is visible showing drawer
    * @example
    * if (drawer.isOpen) {
-   *   console.log('Menu is showing');
+   *   console.log('Drawer is showing');
    * }
    */
   get isOpen() {
@@ -106,7 +95,7 @@ class Drawer extends Backbone.Controller {
   }
 
   /**
-   * Opens drawer in menu mode showing list of registered items.
+   * Opens drawer showing registered drawer items.
    * If only one item registered, automatically triggers its callback.
    * @fires drawer:opened
    * @fires drawer:openedItemView
@@ -119,9 +108,9 @@ class Drawer extends Backbone.Controller {
 
   /**
    * Opens drawer with custom view content.
-   * Called by plugins in response to menu item click.
+   * Called by plugins in response to drawer item click.
    * @param {Backbone.View|jQuery|HTMLElement|string} view - View instance or HTML content to display
-   * @param {boolean} [hasBackButton=true] - Show back button to return to menu
+   * @param {boolean} [hasBackButton=true] - Show back button to return to drawer list
    * @param {string} [position] - Override drawer position ('left'|'right', null uses global config)
    * @fires drawer:opened
    * @fires drawer:openedCustomView
@@ -132,6 +121,7 @@ class Drawer extends Backbone.Controller {
    *   drawer.openCustomView(resourcesView, true, 'right');
    * });
    *
+   * // Or use simple HTML
    * drawer.openCustomView('<div>Simple HTML</div>', false);
    */
   openCustomView(view, hasBackButton, position) {
@@ -139,9 +129,9 @@ class Drawer extends Backbone.Controller {
   }
 
   /**
-   * Registers a menu item in the drawer.
+   * Registers a drawer item.
    * Replaces existing item with same eventCallback.
-   * @param {Object} drawerObject - Menu item configuration
+   * @param {Object} drawerObject - Drawer item configuration
    * @param {string} drawerObject.title - Display title
    * @param {string} drawerObject.description - Description text
    * @param {string} [drawerObject.className] - CSS class for styling
@@ -168,12 +158,15 @@ class Drawer extends Backbone.Controller {
   }
 
   /**
-   * Checks if menu item is registered.
+   * Checks if drawer item is registered.
    * @param {string} eventCallback - Event callback to check
    * @returns {boolean} True if item exists
    * @example
    * if (!drawer.hasItem('resources:showDrawer')) {
-   *   drawer.addItem({ title: 'Resources' }, 'resources:showDrawer');
+   *   drawer.addItem({
+   *     title: 'Resources',
+   *     drawerOrder: 10
+   *   }, 'resources:showDrawer');
    * }
    */
   hasItem(eventCallback) {
@@ -188,6 +181,7 @@ class Drawer extends Backbone.Controller {
    * @example
    * drawer.close();
    *
+   * // Close and focus specific element
    * drawer.close($('.js-nav-home-btn'));
    */
   close($toElement = null) {

--- a/js/drawer.js
+++ b/js/drawer.js
@@ -53,7 +53,11 @@ const DrawerCollection = new Backbone.Collection(null, { comparator: 'drawerOrde
 
 /**
  * @class Drawer
- * @classdesc Singleton service managing drawer sidebar. Only one instance exists per course.
+ * @classdesc Singleton service managing the drawer sidebar. The drawer is a vertical
+ * sidebar that displays registered drawer items (plugin launcher buttons). Clicking
+ * a drawer item switches the sidebar from list view to the plugin's custom view.
+ * Custom views include a back button to return to the drawer item list. Manages
+ * item registration, view lifecycle, and mode switching between list and custom views.
  * @extends {Backbone.Controller}
  */
 class Drawer extends Backbone.Controller {

--- a/js/views/drawerItemView.js
+++ b/js/views/drawerItemView.js
@@ -1,36 +1,17 @@
 /**
- * @file Drawer Item View - Individual menu item in drawer list
+ * @file Drawer Item View - Individual drawer item
  * @module core/js/views/drawerItemView
- * @description Simple view rendering individual menu items in drawer menu mode.
+ * @description Renders individual drawer items in the drawer.
  * Created by {@link DrawerView} for each model in collection. Handles click events
- * and triggers registered callback.
- *
- * **Lifecycle:**
- * - Created by DrawerView.renderItems()
- * - Appends itself to `.drawer__holder`
- * - Listens for `drawer:empty` → self-removes
- * - No explicit remove() call needed
- *
- * **Model Structure Expected:**
- * ```javascript
- * {
- *   eventCallback: 'extension:openSettings',
- *   title: 'Settings',
- *   description: 'Configure course settings',
- *   className: 'settings-item',
- *   drawerOrder: 10
- * }
- * ```
- *
- * **Important:** Created internally by {@link DrawerView}. Use {@link module:core/js/drawer#addItem}
- * to register items, not direct instantiation.
+ * and triggers registered callback. Use {@link module:core/js/drawer#addItem}
+ * to register drawer items.
  */
 
 import Adapt from 'core/js/adapt';
 
 /**
  * @class DrawerItemView
- * @classdesc Renders single drawer menu item button with title and description.
+ * @classdesc Renders single drawer item button with title and description.
  * @extends {Backbone.View}
  */
 class DrawerItemView extends Backbone.View {
@@ -56,6 +37,10 @@ class DrawerItemView extends Backbone.View {
     };
   }
 
+  /**
+   * Renders drawer item button and appends to drawer holder.
+   * @returns {DrawerItemView} This view instance for chaining
+   */
   render() {
     const data = this.model.toJSON();
     const template = Handlebars.templates.drawerItem;
@@ -64,14 +49,18 @@ class DrawerItemView extends Backbone.View {
   }
 
   /**
-   * Handles menu item click.
+   * Handles drawer item click.
    * Triggers the callback event registered with this item.
-   * Drawer service listens to callback and opens custom view.
    * @param {jQuery.Event} event - Click event
    * @example
-   * Adapt.on('resources:showDrawer', () => {
-   *   drawer.openCustomView(new ResourcesView());
+   * // Click event automatically triggers the registered callback
+   * // Model must have eventCallback property
+   * const model = new Backbone.Model({
+   *   eventCallback: 'resources:show',
+   *   title: 'Resources'
    * });
+   * const view = new DrawerItemView({ model });
+   * // User click triggers: Adapt.trigger('resources:show')
    */
   onDrawerItemClicked(event) {
     event.preventDefault();

--- a/js/views/drawerItemView.js
+++ b/js/views/drawerItemView.js
@@ -1,5 +1,38 @@
+/**
+ * @file Drawer Item View - Individual menu item in drawer list
+ * @module core/js/views/drawerItemView
+ * @description Simple view rendering individual menu items in drawer menu mode.
+ * Created by {@link DrawerView} for each model in collection. Handles click events
+ * and triggers registered callback.
+ *
+ * **Lifecycle:**
+ * - Created by DrawerView.renderItems()
+ * - Appends itself to `.drawer__holder`
+ * - Listens for `drawer:empty` → self-removes
+ * - No explicit remove() call needed
+ *
+ * **Model Structure Expected:**
+ * ```javascript
+ * {
+ *   eventCallback: 'extension:openSettings',
+ *   title: 'Settings',
+ *   description: 'Configure course settings',
+ *   className: 'settings-item',
+ *   drawerOrder: 10
+ * }
+ * ```
+ *
+ * **Important:** Created internally by {@link DrawerView}. Use {@link module:core/js/drawer#addItem}
+ * to register items, not direct instantiation.
+ */
+
 import Adapt from 'core/js/adapt';
 
+/**
+ * @class DrawerItemView
+ * @classdesc Renders single drawer menu item button with title and description.
+ * @extends {Backbone.View}
+ */
 class DrawerItemView extends Backbone.View {
 
   className() {
@@ -30,6 +63,16 @@ class DrawerItemView extends Backbone.View {
     return this;
   }
 
+  /**
+   * Handles menu item click.
+   * Triggers the callback event registered with this item.
+   * Drawer service listens to callback and opens custom view.
+   * @param {jQuery.Event} event - Click event
+   * @example
+   * Adapt.on('resources:showDrawer', () => {
+   *   drawer.openCustomView(new ResourcesView());
+   * });
+   */
   onDrawerItemClicked(event) {
     event.preventDefault();
     const eventCallback = this.model.get('eventCallback');

--- a/js/views/drawerView.js
+++ b/js/views/drawerView.js
@@ -1,12 +1,12 @@
 /**
  * @file Drawer View - Main controller for sidebar drawer display and content
  * @module core/js/views/drawerView
- * @description View managing the drawer sidebar with two operational modes: menu list showing
+ * @description View managing the drawer sidebar with two operational modes: drawer list showing
  * registered items via {@link DrawerItemView} or custom view content. Handles positioning,
  * animations, accessibility, and lifecycle management.
  *
  * **Operational Modes:**
- * 1. **Menu Mode** - Shows list of {@link DrawerItemView} instances from collection
+ * 1. **Drawer Mode** - Shows {@link DrawerItemView} instances from collection
  * 2. **Custom Mode** - Shows arbitrary view/HTML with optional back button
  *
  * **Display Behavior:**
@@ -32,21 +32,11 @@
  *
  * **Public Events Triggered:**
  * - `drawer:opened` - Drawer opened (any mode)
- * - `drawer:openedItemView` - Menu mode shown
+ * - `drawer:openedItemView` - Drawer shown
  * - `drawer:openedCustomView` - Custom view shown
  * - `drawer:empty` - Drawer content cleared
  * - `drawer:closed` - Drawer closed
- * - `drawer:noItems` - No menu items in collection
- *
- * **Known Issues & Improvements:**
- * - **Issue:** Single-item workaround (lines 180-188) - Sets `_isCustomViewVisible` to true then immediately false to fix toggle bug, indicates state management problem
- * - **Issue:** Force close hack (line 222) - Uses `css('display', 'block')` to prevent HTMLDialogElement.close() from hiding dialog
- * - **Issue:** Hardcoded selector `.js-nav-drawer-btn` couples view to navigation implementation
- * - **Issue:** Direct DOM manipulation of `$('.js-nav-drawer-btn')` violates separation of concerns
- * - **Enhancement:** Refactor state management to eliminate single-item toggle workaround
- * - **Enhancement:** Use event system instead of direct DOM manipulation for nav button visibility
- * - **Enhancement:** Support configurable drawer button selector
- * - **Enhancement:** Add `drawer:beforeOpen` and `drawer:beforeClose` events for cancellation
+ * - `drawer:noItems` - No drawer items in collection
  *
  * **Important:** Created internally by {@link module:core/js/drawer}. Use drawer service API, not direct instantiation.
  */
@@ -193,7 +183,7 @@ class DrawerView extends Backbone.View {
    * Opens drawer with custom view content.
    * Called by {@link module:core/js/drawer#openCustomView}.
    * @param {Backbone.View|jQuery|HTMLElement|string} view - View instance or HTML content
-   * @param {boolean} [hasBackButton=true] - Show back button to return to menu
+   * @param {boolean} [hasBackButton=true] - Show back button to return to drawer.
    * @param {string} [position] - Override drawer position ('left'|'right')
    * @fires drawer:empty
    * @fires drawer:opened
@@ -213,8 +203,8 @@ class DrawerView extends Backbone.View {
   }
 
   /**
-   * Checks if drawer has menu items and updates nav button visibility.
-   * Directly manipulates nav button DOM (couples to navigation implementation).
+   * Checks if drawer has drawer items and updates drawer button visibility.
+   * Directly manipulates drawer button DOM (couples to toolbar implementation).
    * @fires drawer:noItems
    * @private
    */
@@ -237,9 +227,9 @@ class DrawerView extends Backbone.View {
   }
 
   /**
-   * Checks if drawer is open in menu mode.
+   * Checks if drawer is open showing drawer.
    * Returns false if showing custom view or closed.
-   * @returns {boolean} True if visible in menu mode (not custom view)
+   * @returns {boolean} True if visible showing drawer (not custom view)
    */
   get isOpen() {
     return (this._isVisible && this._isCustomViewVisible === false);
@@ -247,9 +237,9 @@ class DrawerView extends Backbone.View {
 
   /**
    * Opens and displays the drawer with animation.
-   * Handles both menu mode and custom view mode.
+   * Handles both drawer mode and custom view mode.
    * @async
-   * @param {boolean} [emptyDrawer] - True for menu mode, false/null for custom mode
+   * @param {boolean} [emptyDrawer] - True for drawer mode, false/null for custom mode
    * @param {string} [position=null] - Override drawer position
    * @fires drawer:opened
    * @fires drawer:openedItemView
@@ -310,17 +300,23 @@ class DrawerView extends Backbone.View {
   /**
    * Clears drawer content container.
    * @private
+   * @example
+   * this.emptyDrawer();
+   * Adapt.trigger('drawer:empty');
    */
   emptyDrawer() {
     this.$('.drawer__holder').empty();
   }
 
   /**
-   * Renders menu items from collection.
+   * Renders drawer items from collection.
    * Creates {@link DrawerItemView} for each model.
    * Sets ARIA role='list' if multiple items.
    * @fires drawer:empty
    * @private
+   * @example
+   * this.renderItems();
+   * // Triggers drawer:empty and populates drawer with DrawerItemView instances
    */
   renderItems() {
     Adapt.trigger('drawer:empty');
@@ -381,7 +377,8 @@ class DrawerView extends Backbone.View {
    * Cleanup when view is removed.
    * Forces drawer closed, removes event listeners, resets collection.
    * @fires drawer:empty
-   * @param {...*} args - Arguments passed to Backbone's remove method
+   * @example
+   * drawerView.remove();
    */
   remove() {
     this.hideDrawer(null, { force: true });

--- a/js/views/drawerView.js
+++ b/js/views/drawerView.js
@@ -53,6 +53,11 @@ import {
 import logging from '../logging';
 
 /**
+ * @typedef {Object} DrawerCloseOptions
+ * @property {boolean} [force=false] - Skip animation and close drawer immediately
+ */
+
+/**
  * @class DrawerView
  * @classdesc Main drawer controller managing display, positioning, and content rendering.
  * Lifecycle: Created → Positioned → Animated in → User interaction → Animated out → Removed
@@ -332,8 +337,7 @@ class DrawerView extends Backbone.View {
    * Can force immediate close (skip animation).
    * @async
    * @param {jQuery} [$toElement] - Element to focus after closing
-   * @param {Object} [options] - Close options
-   * @param {boolean} [options.force=false] - Skip animation, close immediately
+   * @param {DrawerCloseOptions} [options] - Close options
    * @fires drawer:closed
    * @example
    * await this.hideDrawer();


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)

### Fix
* Fixes #812 

### Update
Added comprehensive JSDoc documentation to the drawer system (3 files):

- **drawer.js** - Singleton service documentation with complete API reference
  - File/module headers with architecture overview
  - Public events section listing all triggered events
  - All public API methods documented: `isOpen`, `open()`, `openCustomView()`, `addItem()`, `hasItem()`, `close()`, `toggle()`, `remove()`
  - Usage examples for menu item registration and custom view patterns
  - Known Issues section documenting DrawerCollection accessibility and missing update methods

- **drawerView.js** - Main controller view documentation
  - File/module headers explaining dual-mode operation (menu/custom view)
  - Configuration options and position logic documented
  - Public events section
  - Key methods documented: `setDrawerPosition()`, `openCustomView()`, `showDrawer()`, `hideDrawer()`, `remove()`
  - Known Issues section identifying single-item toggle workaround, force close hack, and tight coupling to navigation
  - Skipped Backbone config methods per JSDoc style guide

- **drawerItemView.js** - Menu item view documentation
  - File/module headers with lifecycle and model structure
  - Class documentation with usage notes
  - `onDrawerItemClicked()` method documented with callback pattern example
  - Noted internal creation pattern (not for direct instantiation)

All documentation follows the established JSDoc style guide patterns established in the [notify system work](https://github.com/adaptlearning/adapt-contrib-core/pull/811).

[//]: # (List appropriate steps for testing if needed)
### Testing
1. JSDoc generates correctly for all three files
2. Cross-references ({@link}) resolve properly
3. Examples are syntactically valid
4. No JSDoc syntax errors or warnings

[//]: # (Mention any other dependencies)


