### PR TITLE
Fix: Harden execution condition typo (fixes #814)

### DIFF
--- a/js/fixes/harden.js
+++ b/js/fixes/harden.js
@@ -8,7 +8,7 @@ import Adapt from 'core/js/adapt';
 Adapt.on('adapt:start', () => {
   const config = Adapt.config.get('_fixes');
   if (config?._harden !== true) return;
-  if (window.ADAPT_BUILD_TYPE !== 'development') return;
+  if (window.ADAPT_BUILD_TYPE === 'development') return;
   applyHarden();
 });
 


### PR DESCRIPTION
fixes #814 

Harden mistakenly had the opposite run condition.

### Fix
* Fixed the condition of execution by inverting !==

### Testing
Please also test and approve https://github.com/adaptlearning/adapt-contrib-spoor/pull/350
* `config.json:_fixes._harden = true`
* Must be built with `grunt build` or equivalent. 
* Check for `require('core/js/adapt')` in the console. It should not be accessible.
