### PR TITLE
Update: JSDoc documentation for A11y (fixes #829)

### DIFF
--- a/js/a11y.js
+++ b/js/a11y.js
@@ -1,3 +1,48 @@
+/**
+ * @file Accessibility Controller - Core accessibility system managing keyboard and screen reader support.
+ * @module core/js/a11y
+ * @description Singleton service managing the entire accessibility system. Provides API for
+ * managing focus across keyboard and mouse interactions, `aria-hidden` attribute management for screen readers,
+ * popup modal focus containment, aria level calculation for semantic heading hierarchy and
+ * element state validation (tabbable, readable, focusable). Handles complex DOM traversal
+ * and browser-specific quirks in focus behavior.
+ *
+ * **Architecture:**
+ * - Singleton controller (exported as instance)
+ * - Manages focus assignment and validation
+ * - Controls aria-hidden and tabindex attributes
+ * - Manages popup isolation and focus wrapping
+ * - Provides DOM query methods for accessible elements
+ * - Integrates with logging and deprecated API warnings
+ *
+ * **Events:**
+ * - Listens to Adapt events for navigation and content changes to manage focus and visibility
+ * - Triggers `accessibility:ready` when initialized and ready for use
+ *
+ * **Usage:**
+ * ```js
+ * import a11y from 'core/js/a11y';
+ * if (a11y.isEnabled()) {
+ * // Perform accessibility specific setup
+ * }
+ * a11y.focus('.my-element'); // Focus an element
+ * a11y.toggleHidden('.contentobject', true); // Hide content from screen readers
+ * a11y.popupOpened($dialog); // Manage focus for popup
+ * a11y.popupClosed(); // Restore focus after popup closed
+ * a11y.ariaLevel({ id: 'section-1', level: 'page', override: '@page+1' }); // Calculate aria-level
+ * a11y.isTabbable($element); // Check if element is tabbable
+ * a11y.isReadable($element); // Check if element is readable by screen readers
+ * a11y.isFocusable($element); // Check if element can receive focus
+ * a11y.gotoPreviousActiveElement(); // Return focus to previous element
+ * a11y.setPopupCloseTo('.sidebar'); // Set focus target for popup close
+ * a11y.isPopupOpen(); // Check if popup is currently open
+ * a11y.popupStack; // Inspect current popup stack
+ * a11y.log.warn('This is a warning message'); // Log a warning message
+ * a11y.log.removed('This API is removed'); // Log a removed API warning
+ * a11y.log.deprecated('This API is deprecated'); // Log a deprecated API warning
+ * ```
+ */
+
 import Adapt from 'core/js/adapt';
 import offlineStorage from 'core/js/offlineStorage';
 import device from 'core/js/device';
@@ -17,6 +62,14 @@ import deprecated from 'core/js/a11y/deprecated';
 import logging from 'core/js/logging';
 import data from './data';
 
+/**
+ * @class A11y
+ * @classdesc Manages all accessibility features including focus flow, keyboard navigation,
+ * screen reader interaction, and popup isolation. Central service for validating and managing
+ * interactive element accessibility throughout the course.
+ * @extends {Backbone.Controller}
+ * @fires accessibility:ready When accessibility system is initialized and ready
+ */
 class A11y extends Backbone.Controller {
 
   defaults() {
@@ -39,7 +92,7 @@ class A11y extends Backbone.Controller {
       _isPopupAriaHiddenManagementEnabled: true,
       _isPopupTabIndexManagementEnabled: true,
       /**
-       * Do not change aria-hidden on these elements.
+       * Do not change `aria-hidden` on these elements.
        */
       _ariaHiddenExcludes: ':not(#wrapper):not(body)',
       _tabbableElements: 'a,button,input,select,textarea,[tabindex]:not([data-a11y-force-focus])',
@@ -113,6 +166,14 @@ class A11y extends Backbone.Controller {
     });
   }
 
+  /**
+   * Handles config data loaded event from Adapt framework.
+   * Internal event handler called when accessibility configuration is ready.
+   * Initializes accessibility features based on config, triggers 'accessibility:ready' event.
+   * Sets up the focuser div and applies configuration classes.
+   * @private
+   * @fires A11y#accessibility:ready
+   */
   _onConfigDataLoaded() {
     this.config = Adapt.config.get('_accessibility');
     this.config._isActive = false;
@@ -128,6 +189,12 @@ class A11y extends Backbone.Controller {
     Adapt.trigger('accessibility:ready');
   }
 
+  /**
+   * Disables text selection on elements with configured classes.
+   * Internal utility method called to apply u-no-select class when configured.
+   * Prevents accidental text selection during keyboard navigation.
+   * @private
+   */
   _setupNoSelect() {
     if (!this.config?._disableTextSelectOnClasses) {
       return;
@@ -137,6 +204,12 @@ class A11y extends Backbone.Controller {
     this.$html.toggleClass('u-no-select', isMatch);
   }
 
+  /**
+   * Creates or reuses the a11y-focuser div for keyboard focus management.
+   * Internal utility that creates a hidden div with id="a11y-focuser" used by focus()
+   * method for initiating focus events and managing focus state. Only created once.
+   * @private
+   */
   _addFocuserDiv() {
     if ($('#a11y-focuser').length) {
       return;
@@ -144,6 +217,11 @@ class A11y extends Backbone.Controller {
     $('body').append($('<div id="a11y-focuser" class="a11y-ignore" tabindex="-1">&nbsp;</div>'));
   }
 
+  /**
+   * Cleanup method that removes deprecated #accessibility-toggle and #accessibility-instructions
+   * elements from DOM and warns developers to update .html files.
+   * @private
+   */
   _removeLegacyElements() {
     const $legacyElements = $('body').children('#accessibility-toggle, #accessibility-instructions');
     const $navigationElements = $('.nav').find('#accessibility-toggle, #accessibility-instructions');
@@ -155,6 +233,14 @@ class A11y extends Backbone.Controller {
     $navigationElements.remove();
   }
 
+  /**
+   * Internal event handler fired when navigation starts (location change).
+   * Triggered by 'router:location' Adapt event. Hides content objects from screen readers
+   * during page transitions to prevent reading stale content. Should not announce updates
+   * until _onNavigationEnd fires after new content is ready.
+   * @private
+   * @listens Adapt#router:location
+   */
   _onNavigationStart() {
     if (!this.isEnabled()) {
       return;
@@ -163,6 +249,16 @@ class A11y extends Backbone.Controller {
     _.defer(() => this.toggleHidden('.contentobject', true));
   }
 
+  /**
+   * Internal event handler fired when navigation content is fully ready.
+   * Triggered by 'contentObjectView:ready' and 'router:plugin' Adapt events.
+   * Re-enables content visibility to screen readers once new content is rendered.
+   * Validates that this is the correct navigation by comparing model ID with location.
+   * @private
+   * @param {Backbone.View} [view] - The content view that just became ready
+   * @listens Adapt#contentObjectView:ready
+   * @listens Adapt#router:plugin
+   */
   _onNavigationEnd(view) {
     // Prevent sub-menu items provoking behaviour
     if ((view?.model?.get('_id') !== location._currentId) || !this.isEnabled()) {
@@ -172,40 +268,94 @@ class A11y extends Backbone.Controller {
     this.toggleHidden('.contentobject', false);
   }
 
+  /**
+   * Deprecated method retained for backward compatibility.
+   * Accessibility is now always active when enabled. This method only logs a removal
+   * warning and returns false. Use {@link A11y#isEnabled isEnabled()} to check accessibility status.
+   * @deprecated Use {@link A11y#isEnabled isEnabled()} instead
+   * @returns {boolean} Always false
+   */
   isActive() {
     this.log.removed('Accessibility is now always active when enabled. Please unify your user experiences.');
     return false;
   }
 
+  /**
+   * Checks if accessibility features are enabled in the course configuration.
+   * @returns {boolean} True if accessibility is enabled via config._accessibility._isEnabled,
+   *                    false otherwise
+   */
   isEnabled() {
     return this.config?._isEnabled;
   }
 
+  /**
+   * Gets the time in milliseconds since the last focus event occurred.
+   * Used to determine if focus was just changed (very recent) or if significant time
+   * has passed since last focus interaction. Useful for distinguishing user initiated
+   * focus from programmatic focus assignment.
+   * @type {number}
+   * @readonly
+   * @returns {number} Milliseconds since Date.now() when last focus event fired
+   */
   get timeSinceLastFocus() {
     return Date.now() - this._lastFocusTime;
   }
 
+  /**
+   * Gets the element that currently has focus.
+   * Returns the first element in the active element stack, which tracks all elements
+   * that have received focus through focusin events. Independent of
+   * {@link A11y#isForcedFocus isForcedFocus} - includes both user and programmatic focus.
+   * @type {Element}
+   * @readonly
+   * @returns {Element|undefined} Currently focused element, or undefined if no focus history
+   * @see {@link A11y#previousActiveElement previousActiveElement}
+   */
   get currentActiveElement() {
     return this._activeElements[0];
   }
 
+  /**
+   * Gets the element that had focus before the current element.
+   * Returns the second element in the active element stack. Critical for
+   * {@link A11y#gotoPreviousActiveElement gotoPreviousActiveElement()} to restore
+   * focus after dismissing popups and modals. Maintains focus history for returns.
+   * @type {Element}
+   * @readonly
+   * @returns {Element|undefined} Previously focused element, or undefined if insufficient history
+   * @see {@link A11y#currentActiveElement currentActiveElement}
+   * @see {@link A11y#gotoPreviousActiveElement gotoPreviousActiveElement()}
+   */
   get previousActiveElement() {
     return this._activeElements[1];
   }
 
   /**
-   * Calculate the aria level for a heading
-   * @param {object} [options]
-   * @param {string|number} [options.id] Used to automate the heading level when relative increments are used
-   * @param {string|number} [options.level] Specify a default level, "component" / "menu" / "componentItem" etc
-   * @param {string|number} [options.override] Override with a default level, an absolute value or a relative increment
-   * @returns {number}
-   * @notes
-   * Default levels come from config.json:_accessibility._ariaLevels attribute names, they are:
-   *  "menu", "menuGroup", "menuItem", "page", "article", "block", "component", "componentItem" and "notify"
-   * An absolute value would be "1" or "2" etc.
-   * A relative increment would be "@page+1" or "@block+1". They are calculated from ancestor values,
-   * respecting both _ariaLevel overrides and not incrementing for missing displayTitle values.
+   * Calculates the appropriate aria-level for a heading based on content hierarchy.
+   * Computes semantic heading levels using configuration from config.json or relative increments
+   * from ancestor models. Supports absolute values (1-9), type names ("page", "component"),
+   * and relative increments ("@page+1"). Respects _ariaLevel overrides on models and only increments
+   * level when the ancestor has a displayTitle.
+   * @param {Object} [options={}] - Aria level calculation options
+   * @param {string|number} [options.id] - Used to automate the heading level when relative increments are used
+   * @param {string|number} [options.level='1'] - Default level: type name ("page", "component"),
+   *                                               absolute value (1-9), or relative increment ("@page+1")
+   * @param {string|number} [options.override=null] - Override level, takes precedence over default
+   * @returns {number} Computed aria-level (typically 1-6 for standard headings)
+   * @example
+   * // Relative increment from ancestor page level
+   * const level = a11y.ariaLevel({
+   *   id: 'article-1',
+   *   level: 'page',
+   *   override: '@page+1'
+   * });
+   * @example
+   * // Absolute heading level
+   * const level = a11y.ariaLevel({ override: '2' });
+   * @example
+   * // Backward compatible positional arguments (legacy)
+   * const level = a11y.ariaLevel('page', '@page+1');
    */
   ariaLevel({
     id = null,
@@ -263,11 +413,13 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Adds or removes `aria-hidden` attribute to elements.
-   *
-   * @param {Object|string|Array} $elements
-   * @param {boolean} [isHidden=true]
-   * @returns {Object} Chainable
+   * Sets or removes the `aria-hidden` attribute on elements.
+   * Manages screen reader visibility by adding or removing the `aria-hidden="true"` attribute.
+   * When enabled in config, controls whether elements are announced to assistive technology.
+   * Only applies changes if accessibility is enabled and aria-hidden management is configured.
+   * @param {jQuery|string|HTMLElement|Array} $elements - Elements to toggle
+   * @param {boolean} [isHidden=true] - If true, sets aria-hidden; if false, removes it
+   * @returns {A11y} Chainable
    */
   toggleHidden($elements, isHidden = true) {
     $elements = $($elements);
@@ -284,12 +436,16 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Adds or removes `aria-hidden` and `disabled` attributes and `disabled`
-   * classes to elements.
-   *
-   * @param {Object|string|Array} $elements
-   * @param {boolean} [isHidden=true]
-   * @returns {Object} Chainable
+   * Toggles both accessible and enabled states on elements.
+   * Convenience method that calls both {@link A11y#toggleAccessible toggleAccessible()} and
+   * {@link A11y#toggleEnabled toggleEnabled()} to set `aria-hidden` and `disabled` attributes together.
+   * Useful for hiding disabled interactive elements from both keyboard and screen reader users.
+   * @param {jQuery|string|HTMLElement|Array} $elements - Elements to toggle
+   * @param {boolean} [isAccessibleEnabled=true] - If true, enables access and interaction;
+   *                                               if false, disables both
+   * @returns {A11y} Chainable
+   * @see {@link A11y#toggleAccessible toggleAccessible()}
+   * @see {@link A11y#toggleEnabled toggleEnabled()}
    */
   toggleAccessibleEnabled($elements, isAccessibleEnabled) {
     this.toggleAccessible($elements, isAccessibleEnabled);
@@ -298,11 +454,15 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Adds or removes `aria-hidden` attribute and disables `tabindex` on elements.
-   *
-   * @param {Object|string|Array} $elements
-   * @param {boolean} [isReadable=true]
-   * @returns {Object} Chainable
+   * Toggles screen reader visibility by managing `aria-hidden` and `tabindex` attributes.
+   * Controls whether elements are visible to assistive technology and keyboard navigation.
+   * When hidden, sets `tabindex="-1"` and `aria-hidden="true"`, removing from both navigation
+   * and screen reader announcement. Also removes `aria-hidden` from parent elements configured
+   * in `_ariaHiddenExcludes` when re-enabling.
+   * @param {jQuery|string|HTMLElement|Array} $elements - Elements to toggle
+   * @param {boolean} [isReadable=true] - If true, makes element accessible to screen readers
+   *                                      and keyboard; if false, hides from both
+   * @returns {A11y} Chainable
    */
   toggleAccessible($elements, isReadable = true) {
     $elements = $($elements);
@@ -323,11 +483,15 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Adds or removes `disabled` attribute and `disabled` class.
-   *
-   * @param {Object|string|Array} $elements
-   * @param {boolean} [isEnabled=true]
-   * @returns {Object} Chainable
+   * Toggles the disabled state on elements using `aria-disabled` attribute and `is-disabled` class.
+   * Manages the visual and programmatic disabled state of interactive elements. Sets
+   * `aria-disabled="true"` and applies the `is-disabled` CSS class when disabled.
+   * This approach allows styling disabled elements while preserving focusability for
+   * keyboard and screen reader users (who get "disabled" announcements via aria-disabled).
+   * @param {jQuery|string|HTMLElement|Array} $elements - Elements to toggle
+   * @param {boolean} [isEnabled=true] - If true, enables interaction;
+   *                                     if false, marks as disabled
+   * @returns {A11y} Chainable
    */
   toggleEnabled($elements, isEnabled = true) {
     $elements = $($elements);
@@ -345,10 +509,14 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Toggles tabindexes off and on all tabbable descendants.
-   * @param {Object|string|Array} $element
-   * @param {boolean} isTabbable
-   * @returns {Object} Chainable
+   * Toggles keyboard tab focus on all tabbable descendant elements.
+   * Manages `tabindex` attributes on all descendants with tab capability. When hiding,
+   * stores the original `tabindex` value and sets to -1, marking elements with
+   * `isAdaptTabHidden` flag to avoid multiple hiding. When showing, restores original
+   * tabindex values. Useful for managing focus scope in modals or collapsed regions.
+   * @param {jQuery|string|HTMLElement|Array} $element - Parent element containing tabbable descendants
+   * @param {boolean} [isTabbable=true] - If true, restores keyboard focus; if false, removes from tab order
+   * @returns {A11y} Chainable
    */
   toggleTabbableDescendants($element, isTabbable = true) {
     const $tabbable = this.findTabbable($element);
@@ -375,9 +543,13 @@ class A11y extends Backbone.Controller {
 
   /**
    * Find the first tabbable element after the specified element.
-   *
-   * @param {Object|string|Array} $element
-   * @returns {Object}
+   * Searches forward from the specified element and its descendants using depth-first
+   * tree traversal to locate the first element that passes the `isTabbable()` check.
+   * Returns a jQuery object (empty if no tabbable element found). Used by {@link A11y#focusNext focusNext()}
+   * to navigate to the next keyboard-accessible element.
+   * @param {jQuery|string|HTMLElement|Array} $element - Starting element to search from
+   * @returns {jQuery} jQuery object containing the first tabbable element, or empty jQuery if not found
+   * @see {@link A11y#isTabbable isTabbable()}  for definition of keyboard tabbable
    */
   findFirstTabbable($element) {
     $element = $($element).first();
@@ -385,10 +557,14 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Find the first readable element after the specified element.
-   *
-   * @param {Object|string|Array} $element
-   * @returns {Object}
+   * Finds the first readable element after the specified element.
+   * Searches forward from the specified element using depth-first traversal to find
+   * the first element where `isReadable()` returns true. A readable element is not hidden
+   * from screen readers (`aria-hidden` attribute absent/false). Used for screen reader
+   * navigation when keyboard tabbability isn't required.
+   * @param {jQuery|string|HTMLElement|Array} $element - Starting element to search from
+   * @returns {jQuery} jQuery object containing the first readable element, or empty jQuery if not found
+   * @see {@link A11y#isReadable isReadable()}  for screen reader visibility rules
    */
   findFirstReadable($element) {
     $element = $($element).first();
@@ -396,10 +572,13 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Find the first focusable element after the specified element.
-   *
-   * @param {Object|string|Array} $element
-   * @returns {Object}
+   * Finds the first element that is both keyboard tabbable and screen-reader accessible.
+   * Searches forward using tree traversal for the first element where `isFocusable()`
+   * returns true (must pass both `isTabbable()` and `isReadable()` checks). Most restrictive
+   * of the first* find methods. Primary method used by {@link A11y#focusFirst focusFirst()} for focus management.
+   * @param {jQuery|string|HTMLElement|Array} $element - Starting element to search from
+   * @returns {jQuery} jQuery object containing the first focusable element, or empty jQuery if not found
+   * @see {@link A11y#isFocusable isFocusable()}  for complete focusability criteria
    */
   findFirstFocusable($element) {
     $element = $($element).first();
@@ -407,10 +586,13 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Find all tabbable elements in the specified element.
-   *
-   * @param {Object|string|Array} $element
-   * @returns {Object}
+   * Find all tabbable elements within the specified element.
+   * Returns all descendants that are keyboard navigable (pass `isTabbable()` check).
+   * Uses selector based filtering rather than tree traversal for efficiency when you need
+   * all tabbable elements. Common use in {@link A11y#toggleTabbableDescendants toggleTabbableDescendants()}
+   * to manage focus trap scope in modals.
+   * @param {jQuery|string|HTMLElement|Array} $element - Container element to search within
+   * @returns {jQuery} jQuery collection of all tabbable descendants
    */
   findTabbable($element) {
     const config = this.config;
@@ -418,28 +600,38 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Find all readable elements in the specified element.
-   *
-   * @param {Object|string|Array} $element
+   * Finds all readable elements within the specified element.
+   * Returns all descendants that are visible to assistive technology (not hidden via
+   * `aria-hidden="true"`). Uses full DOM traversal with `isReadable()` filter. More comprehensive
+   * than findTabbable but includes non-interactive content. Useful for screen reader
+   * content analysis and accessibility auditing.
+   * @param {jQuery|string|HTMLElement|Array} $element - Container element to search within
+   * @returns {jQuery} jQuery collection of all readable descendants
    */
   findReadable($element) {
     return $($element).find('*').filter((index, element) => this.isReadable(element));
   }
 
   /**
-   * Find all focusable elements in the specified element.
-   *
-   * @param {Object|string|Array} $element
+   * Finds all focusable elements within the specified element.
+   * Returns descendants where both `isTabbable()` and `isReadable()` are true. Most restrictive
+   * collection method. Useful for analyzing interactive and accessible elements in a region.
+   * @param {jQuery|string|HTMLElement|Array} $element - Container element to search within
+   * @returns {jQuery} jQuery collection of all focusable descendants
    */
   findFocusable($element) {
     return $($element).find('*').filter((index, element) => this.isFocusable(element));
   }
 
   /**
-   * Check if the element is natively or explicitly tabbable.
-   *
-   * @param {Object|string|Array} $element
-   * @returns {boolean|undefined}
+   * Checks if the element is natively or explicitly tabbable.
+   * Tests whether an element matches the configured `_tabbableElements` selector
+   * and doesn't match the `_tabbableElementsExcludes` selector. Used by tree traversal
+   * methods to determine keyboard navigation order.
+   * @param {jQuery|string|HTMLElement|Array} $element - Element to test
+   * @returns {boolean|null} Returns true if tabbable, false if explicitly excluded,
+   *                         or null ("keep descending") if not directly tabbable but may have tabbable children
+   * @see {@link A11y#_findFirstForward _findFirstForward()} for tree traversal behavior
    */
   isTabbable($element) {
     const config = this.config;
@@ -451,11 +643,19 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Check if the first item is readable by a screen reader.
-   *
-   * @param {Object|string|Array} $element
-   * @param {boolean} [checkParents=true] Check if parents are inaccessible.
-   * @returns {boolean}
+   * Checks if the element is visible and readable by screen reader software.
+   * Comprehensive visibility check examining display, visibility, aria-hidden properties,
+   * and content presence. Returns true if element is in DOM, has screen readable content
+   * (text nodes, `aria-label`, `aria-labelledby`, or input with value), and is not hidden.
+   * Returns null ("continue descending") if element has no readable content itself but might
+   * have readable children (for tree traversal algorithms). Special handling for popups:
+   * returns null if outside open popup (signals to skip but continue searching).
+   * @param {jQuery|string|HTMLElement|Array} $element - Element to test
+   * @param {boolean} [checkParents=true] - If true, also checks parent chain for hidden/removed states;
+   *                                        if false, only checks the element itself
+   * @returns {boolean|null} Returns true if screen reader accessible, false if hidden,
+   *                         or null to allow tree traversal to descend and continue searching
+   * @see {@link A11y#_findFirstForward _findFirstForward()} for tree traversal behavior
    */
   isReadable($element, checkParents = true) {
     const config = this.config;
@@ -509,11 +709,20 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Check if the first item is readable by a screen reader.
-   *
-   * @param {Object|string|Array} $element
-   * @param {boolean} [checkParents=true] Check if parents are inaccessible.
-   * @returns {boolean}
+   * Checks if the element is both keyboard tabbable and screen reader accessible.
+   * Combines `isTabbable()` (keyboard focus capability) with `isReadable()` (screen reader visibility)
+   * checks. First validates that element doesn't match `_focusForwardElementsExcludes` (returns null if excluded,
+   * allowing tree traversal to skip this item but continue with siblings), then checks readability.
+   * Used by {@link A11y#focusFirst focusFirst()} and related focus methods as the definitive
+   * test for whether an element should receive programmatic or user focus.
+   * @param {jQuery|string|HTMLElement|Array} $element - Element to test
+   * @param {boolean} [checkParents=true] - If true, checks parent chain visibility;
+   *                                        if false, only checks element itself
+   * @returns {boolean|null} Returns true if fully focusable, false if not readable,
+   *                         or null if excluded from focus traversal (allows descending)
+   * @see {@link A11y#isTabbable isTabbable()}
+   * @see {@link A11y#isReadable isReadable()}
+   * @see {@link A11y#_findFirstForward _findFirstForward()} for tree traversal usage
    */
   isFocusable($element, checkParents = true) {
     const config = this.config;
@@ -523,10 +732,12 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Check if the first item uses keyboard arrows for interactions.
-   *
-   * @param {Object|string|Array} $element
-   * @returns {boolean}
+   * Checks if the first element uses arrow keys for keyboard interactions.
+   * Tests whether element matches the `_arrowElements` selector, typically used for composite
+   * widgets like toolbars, menus, and tabs that respond to arrow key navigation. Used to
+   * suppress tab navigation and enable arrow key handling.
+   * @param {jQuery|string|HTMLElement|Array} $element - Element to test
+   * @returns {boolean} True if element supports arrow key navigation, false otherwise
    */
   isArrowable($element) {
     const config = this.config;
@@ -535,17 +746,24 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Find forward in the DOM, descending and ascending to move forward
-   * as appropriate.
+   * Core algorithm used by all find methods for depth-first DOM traversal.
+   * Searches forward from an element through descendants, then siblings, then ancestor siblings, recursively
+   * checking each branch. Supports function based iteration with special return value semantics:
+   * - true: Found match, return immediately
+   * - false: Skip this branch, don't descend into children
+   * - undefined/null: No match at this node, but descend into children for further searching
    *
-   * If the selector is a function it should returns true, false or undefined.
-   * Returning true matches the item and returns it. Returning false means do
-   * not match or descend into this item, returning undefined means do not match,
-   * but descend into this item.
-   *
-   * @param {Object|string|Array} $element
-   * @param {string|function|undefined} selector
-   * @returns {Object} Returns found descendant.
+   * The iterator function can be:
+   * - A string CSS selector (converted to equality test via jQuery.is())
+   * - A function taking jQuery element and returning true/false/undefined
+   * - Undefined (matches first element found)
+   * @private
+   * @param {jQuery|HTMLElement} $element - Starting element for forward search
+   * @param {string|Function|undefined} selector - Selector logic: string selector, iterator function,
+   *                                               or undefined for "find any element"
+   * @returns {jQuery} jQuery object containing matched element, or empty jQuery if not found
+   * @see {@link A11y#_findFirstForwardDescendant _findFirstForwardDescendant()} for descendant traversal
+   * @see {@link A11y#findFirstFocusable findFirstFocusable()}, {@link A11y#findFirstReadable findFirstReadable()}\n   * for public APIs using this algorithm
    */
   _findFirstForward($element, selector) {
     $element = $($element).first();
@@ -639,17 +857,21 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Find descendant in a DOM tree, work from selected to branch-end, through allowed
-   * branch structures in hierarchy order
-   *
-   * If the selector is a function it should returns true, false or undefined.
-   * Returning true matches the item and returns it. Returning false means do
-   * not match or descend into this item, returning undefined means do not match,
-   * but descend into this item.
-   *
-   * @param {Object|string|Array} $element jQuery element to start from.
-   * @param {string|function|undefined} selector
-   * @returns {Object} Returns found descendant.
+   * Descendant-only tree traversal for finding matched elements.
+   * Worker method called by {@link A11y#_findFirstForward _findFirstForward()} to search
+   * within an element's entire subtree (current element, then all children/descendants).
+   * Uses depth-first traversal with an explicit stack to avoid excessive recursion.
+   * Children are injected at the correct position in the stack to maintain depth-first
+   * order, checking parents before their children's siblings.
+   * Iterator function return values:
+   * - true: Element matches, return it immediately
+   * - false: Element explicitly excluded, skip it and its descendants
+   * - undefined: Element doesn't match, but descend into its children
+   * @private
+   * @param {jQuery|HTMLElement} $element - Root element to search within
+   * @param {string|Function|undefined} selector - Selector logic (same semantics as _findFirstForward)
+   * @returns {jQuery} jQuery object containing matched element, or empty jQuery if not found
+   * @see {@link A11y#_findFirstForward _findFirstForward()} for the main traversal algorithm
    */
   _findFirstForwardDescendant($element, selector) {
     $element = $($element).first();
@@ -726,11 +948,16 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Assign focus to the next readable element.
-   *
-   * @param {Object|string|Array} $element
-   * @param {FocusOptions} options
-   * @returns {Object} Chainable
+   * Assigns focus to the next focusable element after the specified element.
+   * Searches forward from the supplied element for the first focusable descendant or
+   * sibling, then assigns focus to it. Useful for implementing custom focus navigation
+   * after interactive element changes. Respects FocusOptions for deferred focus and
+   * scroll prevention (important for Safari, Edge, IE11 where preventScroll isn't fully supported).
+   * @param {jQuery|string|HTMLElement|Array} $element - Starting element for forward search
+   * @param {FocusOptions|Object} [options] - Focus assignment options
+   * @param {boolean} [options.defer=false] - Defer focus assignment to next event loop
+   * @param {boolean} [options.preventScroll=false] - Prevent automatic scroll to focused element
+   * @returns {A11y} Chainable
    */
   focusNext($element, options) {
     options = new FocusOptions(options);
@@ -741,12 +968,17 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Assign focus to either the specified element if it is readable or the
-   * next readable element.
-   *
-   * @param {Object|string|Array} $element
-   * @param {FocusOptions} options
-   * @returns {Object}
+   * Assigns focus to the specified element or the next readable element.
+   * Checks if the supplied element is readable; if so, focuses it directly. Otherwise,
+   * finds and focuses the first readable element within. Special case: when element is
+   * document.body, forces focus to the top of content for keyboard navigation restart.
+   * Critical for menu and page navigation to work correctly with keyboard and
+   * screen reader users.
+   * @param {jQuery|string|HTMLElement|Array} $element - Element to focus or search within
+   * @param {FocusOptions|Object} [options] - Focus assignment options
+   * @param {boolean} [options.defer=false] - Defer focus assignment to next event loop
+   * @param {boolean} [options.preventScroll=false] - Prevent automatic scroll to focused element
+   * @returns {jQuery|A11y} Element that received focus, or chainable if deferred
    */
   focusFirst($element, options) {
     options = new FocusOptions(options);
@@ -767,11 +999,20 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Force focus to the specified element with/without a defer or scroll.
-   *
-   * @param {Object|string|Array} $element
-   * @param {FocusOptions} options
-   * @returns {Object} Chainable
+   * Force focus to the specified element with optional defer and scroll control.
+   * Directly sets focus on an element, bypassing normal focus capture events by setting
+   * the `_isForcedFocus` flag. This allows distinguishing between user triggered focus
+   * (keyboard/click) and programmatic focus. Sets `tabindex="0"` and `data-a11y-force-focus="true"`
+   * attributes on the element. Handles cross-browser `preventScroll` behavior (Safari, Edge, IE11
+   * require manual scroll position restoration). When element is document.body, focuses the
+   * top-of-content object instead for proper screen reader announcements.
+   * @param {jQuery|string|HTMLElement|Array} $element - Element to receive focus
+   * @param {FocusOptions|Object} [options] - Focus control options
+   * @param {boolean} [options.defer=false] - If true, uses _.defer() to delay focus assignment
+   *                                          to next event loop iteration
+   * @param {boolean} [options.preventScroll=false] - Prevent viewport scroll to focused element
+   *                                                  (shim for Safari, Edge, IE11 limitations)
+   * @returns {A11y} Chainable
    */
   focus($element, options) {
     options = new FocusOptions(options);
@@ -827,8 +1068,11 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Sends focus to previous active element
-   * Useful for returning from a close notify push
+   * Restores focus to the previously active element before the current focus change.
+   * Useful for returning focus after dismissing modals, notifications, or popups.
+   * Maintains a stack of active elements to support nested interactions. Falls back to
+   * focusing the navigation menu if no previous active element exists.
+   * @returns {void}
    */
   gotoPreviousActiveElement() {
     if (!this.previousActiveElement) return a11y.focusFirst(Adapt.navigation);
@@ -843,10 +1087,13 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Used to convert html to text aria-labels.
-   *
-   * @param {string} htmls Any html strings.
-   * @returns {string} Returns text without markup or html encoded characters.
+   * Converts HTML to plain text suitable for aria-labels and screen reader announcements.
+   * Strips all HTML tags and converts HTML entities (like &apos;, &quot;) to their textual
+   * equivalents. Uses a temporary DOM element to parse HTML, then removes encoded characters
+   * using regex. Accepts multiple arguments (like sprintf) which are filtered and joined with spaces.
+   * Essential for converting rich content HTML into accessible text announcements.
+   * @param {...string} htmls - One or more HTML strings to normalize
+   * @returns {string} Plain text without markup or encoded HTML entities
    */
   normalize(htmls) {
     htmls = [...arguments].filter(Boolean).filter(_.isString).join(' ');
@@ -856,12 +1103,14 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Removes all html tags except stylistic elements.
-   * Useful for producing uninterrupted text for screen readers from
-   * any html.
-   *
-   * @param  {string} htmls Any html strings.
-   * @return {string} Returns html string without markup which would cause screen reader to pause.
+   * Removes block-level and semantic HTML tags while preserving inline stylistic elements.
+   * Filters out tags that would cause screen readers to pause (like div, p, br, h1-h6),
+   * but preserves semantic styling (b, strong, em, i, span, etc. as configured in `_wrapStyleElements`).
+   * Critical for converting structured content into uninterrupted screen reader announcements.
+   * Uses recursive DOM traversal to collect text nodes and style-safe elements, then reconstructs
+   * as continuous HTML. Accepts multiple arguments which are joined before processing.
+   * @param {...string} htmls - One or more HTML strings to process
+   * @returns {string} HTML string with pause-causing tags removed, preserving semantic formatting
    */
   removeBreaks(htmls) {
     htmls = [...arguments].filter(Boolean).filter(_.isString).join(' ');
@@ -896,8 +1145,14 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * @param {Object|string|Array} $elements
-   * @returns {Object} Chainable
+   * Enables scroll event handling on the specified elements.
+   * Delegates to the internal {@link Scroll} controller to allow normal scroll
+   * behavior on previously scroll-blocked elements. Re-enables touch, wheel, and keyboard
+   * scroll events. Used when exiting modals or popups that should trap scroll.
+   * @param {jQuery|string|HTMLElement|Array} $elements - Elements to enable scrolling on
+   * @returns {A11y} Chainable
+   * @see {@link A11y#scrollDisable scrollDisable()}
+   * @see {@link Scroll} controller for detailed scroll management
    */
   scrollEnable($elements) {
     this._scroll.enable($elements);
@@ -905,8 +1160,15 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * @param {Object|string|Array} $elements
-   * @returns {Object} Chainable
+   * Disables scroll event handling on the specified elements.
+   * Delegates to the internal {@link Scroll} controller to prevent scrolling via touch,
+   * mouse wheel, or keyboard (spacebar, page down, arrow keys) on specified elements.
+   * Essential for implementing modal and popup scroll traps to prevent inadvertent scrolling
+   * of background content while a modal is open.
+   * @param {jQuery|string|HTMLElement|Array} $elements - Elements to disable scrolling on
+   * @returns {A11y} Chainable
+   * @see {@link A11y#scrollEnable scrollEnable()}
+   * @see {@link Scroll} controller for detailed scroll blocking mechanism
    */
   scrollDisable($elements) {
     this._scroll.disable($elements);
@@ -914,10 +1176,16 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * To apply accessibilty handling to a tag, isolating the user.
-   *
-   * @param {Object} $popupElement Element encapsulating the popup.
-   * @returns {Object} Chainable
+   * Applies accessibility isolation to a popup element and manages focus trapping.
+   * Delegates to the internal {@link Popup} controller to apply accessibility handling
+   * to a popup/modal: sets aria-hidden on background, manages focus trap, disables background
+   * scrolling, manages return focus on close targets. Should be called immediately when popup
+   * becomes visible to users.
+   * @param {jQuery|HTMLElement|string} $popupElement - Root element of the popup to isolate
+   * @returns {A11y} Chainable
+   * @see {@link A11y#popupClosed popupClosed()}
+   * @see {@link A11y#setPopupCloseTo setPopupCloseTo()}
+   * @see {@link Popup} controller for detailed popup accessibility management
    */
   popupOpened($popupElement) {
     this._popup.opened($popupElement);
@@ -925,10 +1193,18 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Remove the isolation applied with a call to `popupOpened`.
-   *
-   * @param {Object} [$focusElement] Element to move focus to.
-   * @returns {Object} Chainable
+   * Removes accessibility isolation from a popup and restores focus to background.
+   * Delegates to the internal {@link Popup} controller to reverse the effects of
+   * {@link A11y#popupOpened popupOpened()}: removes `aria-hidden` from background,
+   * ends focus trap, re-enables background scrolling, optionally refocuses a specific element
+   * (or the element configured via {@link A11y#setPopupCloseTo setPopupCloseTo()}).
+   * Should be called when popup is hidden from users.
+   * @param {jQuery|HTMLElement|string} [$focusElement] - Optional element to focus after closing;
+   *                                                      if omitted, uses element set via setPopupCloseTo()
+   * @returns {A11y} Chainable
+   * @see {@link A11y#popupOpened popupOpened()}
+   * @see {@link A11y#setPopupCloseTo setPopupCloseTo()}
+   * @see {@link Popup} controller for detailed popup accessibility management
    */
   popupClosed($focusElement) {
     this._popup.closed($focusElement);
@@ -936,20 +1212,46 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * When a popup is open, this function makes it possible to swap the element
-   * that should receive focus on popup close.
-   *
-   * @param {Object} $focusElement Set a new element to focus on.
-   * @returns {Object} Returns previously set focus element.
+   * Sets the element that should receive focus when the current popup closes.
+   * Stores focus-return target while popup is open, useful when the element that
+   * triggered the popup has been removed or relocated. Delegates to the internal
+   * {@link Popup} controller. If not called, focus returns to whatever element
+   * was active before {@link A11y#popupOpened popupOpened()} was called.
+   * @param {jQuery|HTMLElement|string} $focusElement - Element to receive focus on close
+   * @returns {jQuery|null} Previously set focus element, or null if none was set
+   * @see {@link A11y#popupOpened popupOpened()}
+   * @see {@link A11y#popupClosed popupClosed()}
    */
   setPopupCloseTo($focusElement) {
     return this._popup.setCloseTo($focusElement);
   }
 
+  /**
+   * Checks if a popup is currently open and has isolation applied.
+   * Queries the internal {@link Popup} controller to determine if any popup is actively
+   * managing focus trap, aria-hidden, and scroll restrictions. Used to validate whether
+   * elements should be included in focus traversal or hidden from screen readers.
+   * @type {boolean}
+   * @readonly
+   * @returns {boolean} True if popup isolation is active, false otherwise
+   * @see {@link A11y#popupOpened popupOpened()}
+   * @see {@link A11y#popupClosed popupClosed()}
+   */
   get isPopupOpen() {
     return this._popup.isOpen;
   }
 
+  /**
+   * Gets the internal popup stack tracking all nested popups.
+   * Returns reference to the {@link Popup} controller's internal stack data structure
+   * that tracks the hierarchy of nested/stacked popups. Used for inspecting current
+   * popup state and determining focus containment boundaries.
+   * @type {Stack|undefined}
+   * @readonly
+   * @returns {Stack|undefined} Stack data structure with lastItem property tracking topmost popup,
+   *                           or undefined if no popups are open
+   * @see {@link A11y#isPopupOpen isPopupOpen()}
+   */
   get popupStack() {
     return this._popup.stack;
   }

--- a/js/a11y.js
+++ b/js/a11y.js
@@ -572,7 +572,7 @@ class A11y extends Backbone.Controller {
   }
 
   /**
-   * Finds the first element that is both keyboard tabbable and screen-reader accessible.
+   * Finds the first element that is both keyboard tabbable and screen reader accessible.
    * Searches forward using tree traversal for the first element where `isFocusable()`
    * returns true (must pass both `isTabbable()` and `isReadable()` checks). Most restrictive
    * of the first* find methods. Primary method used by {@link A11y#focusFirst focusFirst()} for focus management.

--- a/js/a11y/ariaDisabled.js
+++ b/js/a11y/ariaDisabled.js
@@ -49,13 +49,6 @@ export default class BrowserFocus extends Backbone.Controller {
     return isAriaDisabled;
   }
 
-  /**
-   * Prevents click events from being processed on aria-disabled elements.
-   * Only responds to trusted user events, not synthetic events.
-   * @private
-   * @param {jQuery.Event} event - The click event object
-   * @returns {void}
-   */
   _onClick(event) {
     if (!event.isTrusted) return;
     const $element = $(event.target);
@@ -64,13 +57,6 @@ export default class BrowserFocus extends Backbone.Controller {
     event.stopImmediatePropagation();
   }
 
-  /**
-   * Prevent Enter and Space key presses from activating aria-disabled elements.
-   * Only responds to trusted user events, not synthetic events.
-   * @private
-   * @param {jQuery.Event} event - The keydown event object
-   * @returns {void}
-   */
   _onKeyDown(event) {
     if (!event.isTrusted) return;
     if (!['Enter', ' '].includes(event.key)) return;

--- a/js/a11y/ariaDisabled.js
+++ b/js/a11y/ariaDisabled.js
@@ -1,11 +1,21 @@
+/**
+ * @file Aria Disabled - Prevents interaction with aria-disabled elements
+ * @module core/js/a11y/ariaDisabled
+ * @description Intercepts keyboard and click events on elements marked with
+ * aria-disabled="true" to prevent their activation. Also checks for aria-disabled
+ * on associated label 'for' attributes. Only responds to trusted user events.
+ */
+
 import Adapt from 'core/js/adapt';
 
 /**
- * Browser aria-disabled element interaction prevention
- * @class
+ * @class BrowserFocus
+ * @classdesc Prevents activation of elements marked with aria-disabled="true".
+ * @extends Backbone.Controller
+ * @see https://github.com/adaptlearning/adapt_framework/issues/3097
+ * @see https://github.com/adaptlearning/adapt-contrib-core/issues/623
  */
 export default class BrowserFocus extends Backbone.Controller {
-
   initialize({ a11y }) {
     this.a11y = a11y;
     this._onKeyDown = this._onKeyDown.bind(this);
@@ -22,6 +32,14 @@ export default class BrowserFocus extends Backbone.Controller {
     this.$body[0].addEventListener('click', this._onClick, true);
   }
 
+  /**
+   * Checks if an element or its associated label is marked as aria-disabled.
+   * Searches up the DOM tree for aria-disabled="true" on the element itself
+   * or its parents.
+   * Checks if the element is an input with a label that has aria-disabled="true".
+   * @param {jQuery} $element - The jQuery-wrapped DOM element to check
+   * @returns {boolean} True if the element or its label is aria-disabled, false otherwise
+   */
   isAriaDisabled($element) {
     // search element and parents for aria-disabled - see https://github.com/adaptlearning/adapt_framework/issues/3097
     // search closest 'for' element for aria-disabled - see https://github.com/adaptlearning/adapt-contrib-core/issues/623
@@ -32,9 +50,11 @@ export default class BrowserFocus extends Backbone.Controller {
   }
 
   /**
-   * Stop click handling on aria-disabled elements.
-   *
-   * @param {JQuery.Event} event
+   * Prevents click events from being processed on aria-disabled elements.
+   * Only responds to trusted user events, not synthetic events.
+   * @private
+   * @param {jQuery.Event} event - The click event object
+   * @returns {void}
    */
   _onClick(event) {
     if (!event.isTrusted) return;
@@ -45,9 +65,11 @@ export default class BrowserFocus extends Backbone.Controller {
   }
 
   /**
-   * Stop enter and space handling on aria-disabled elements.
-   *
-   * @param {JQuery.Event} event
+   * Prevent Enter and Space key presses from activating aria-disabled elements.
+   * Only responds to trusted user events, not synthetic events.
+   * @private
+   * @param {jQuery.Event} event - The keydown event object
+   * @returns {void}
    */
   _onKeyDown(event) {
     if (!event.isTrusted) return;

--- a/js/a11y/ariaDisabled.js
+++ b/js/a11y/ariaDisabled.js
@@ -2,7 +2,7 @@
  * @file Aria Disabled - Prevents interaction with aria-disabled elements
  * @module core/js/a11y/ariaDisabled
  * @description Intercepts keyboard and click events on elements marked with
- * aria-disabled="true" to prevent their activation. Also checks for aria-disabled
+ * aria-disabled="true" to prevent their activation. Checks for aria-disabled
  * on associated label 'for' attributes. Only responds to trusted user events.
  */
 

--- a/js/a11y/ariaDisabled.js
+++ b/js/a11y/ariaDisabled.js
@@ -9,13 +9,13 @@
 import Adapt from 'core/js/adapt';
 
 /**
- * @class BrowserFocus
+ * @class AriaDisabled
  * @classdesc Prevents activation of elements marked with aria-disabled="true".
  * @extends Backbone.Controller
  * @see https://github.com/adaptlearning/adapt_framework/issues/3097
  * @see https://github.com/adaptlearning/adapt-contrib-core/issues/623
  */
-export default class BrowserFocus extends Backbone.Controller {
+export default class AriaDisabled extends Backbone.Controller {
   initialize({ a11y }) {
     this.a11y = a11y;
     this._onKeyDown = this._onKeyDown.bind(this);

--- a/js/a11y/browserConfig.js
+++ b/js/a11y/browserConfig.js
@@ -25,13 +25,6 @@ import Adapt from '../adapt';
  */
 export default class BrowserConfig extends Backbone.Controller {
 
-  /**
-   * Initializes the browser configuration controller.
-   * Stores reference to the A11y module and sets up event listeners
-   * for accessibility ready state.
-   * @param {Object} options - Configuration options
-   * @param {Object} options.a11y - Reference to the parent A11y module instance
-   */
   initialize({ a11y }) {
     this.a11y = a11y;
     this.listenTo(Adapt, {
@@ -39,18 +32,10 @@ export default class BrowserConfig extends Backbone.Controller {
     });
   }
 
-  /**
-   * Handles accessibility ready event.
-   * @private
-   */
   _onReady() {
     if (this.a11y.config._options._isPrefersReducedMotionEnabled) this._enablePrefersReducedMotion();
   }
 
-  /**
-   * Enables prefers-reduced-motion detection and applies CSS class.
-   * @private
-   */
   _enablePrefersReducedMotion() {
     if (!window.matchMedia) return;
     const isEnabledInBrowser = window.matchMedia('(prefers-reduced-motion: reduce');

--- a/js/a11y/browserConfig.js
+++ b/js/a11y/browserConfig.js
@@ -1,11 +1,37 @@
+/**
+ * @file Browser Configuration - Accessibility browser feature detection
+ * @module core/js/a11y/browserConfig
+ * @description Handles browser-level accessibility configuration, particularly
+ * detecting and responding to user preferences like reduced motion settings.
+ * Applies appropriate CSS classes to the document based on browser capabilities
+ * and user preferences.
+ *
+ * **Responsibilities:**
+ * - Detects `prefers-reduced-motion` media query preference
+ * - Applies `is-prefers-reduced-motion` class to HTML element when enabled
+ * - Integrates with the A11y module configuration system
+ *
+ * @example
+ * import BrowserConfig from 'core/js/a11y/browserConfig';
+ * const browserConfig = new BrowserConfig({ a11y });
+ */
+
 import Adapt from '../adapt';
 
 /**
- * Browser configuration helper.
- * @class
+ * @class BrowserConfig
+ * @classdesc Detects browser accessibility preferences and applies CSS class.
+ * @extends Backbone.Controller
  */
 export default class BrowserConfig extends Backbone.Controller {
 
+  /**
+   * Initializes the browser configuration controller.
+   * Stores reference to the A11y module and sets up event listeners
+   * for accessibility ready state.
+   * @param {Object} options - Configuration options
+   * @param {Object} options.a11y - Reference to the parent A11y module instance
+   */
   initialize({ a11y }) {
     this.a11y = a11y;
     this.listenTo(Adapt, {
@@ -13,10 +39,18 @@ export default class BrowserConfig extends Backbone.Controller {
     });
   }
 
+  /**
+   * Handles accessibility ready event.
+   * @private
+   */
   _onReady() {
     if (this.a11y.config._options._isPrefersReducedMotionEnabled) this._enablePrefersReducedMotion();
   }
 
+  /**
+   * Enables prefers-reduced-motion detection and applies CSS class.
+   * @private
+   */
   _enablePrefersReducedMotion() {
     if (!window.matchMedia) return;
     const isEnabledInBrowser = window.matchMedia('(prefers-reduced-motion: reduce');

--- a/js/a11y/browserFocus.js
+++ b/js/a11y/browserFocus.js
@@ -24,12 +24,6 @@ import Adapt from 'core/js/adapt';
  */
 export default class BrowserFocus extends Backbone.Controller {
 
-  /**
-   * Initializes the browser focus controller.
-   * Binds event handlers, caches body element, and sets up accessibility ready listener.
-   * @param {Object} options - Configuration options
-   * @param {Object} options.a11y - Reference to the parent A11y module instance
-   */
   initialize({ a11y }) {
     this.a11y = a11y;
     this._onBlur = this._onBlur.bind(this);

--- a/js/a11y/browserFocus.js
+++ b/js/a11y/browserFocus.js
@@ -15,6 +15,7 @@
  * import BrowserFocus from 'core/js/a11y/browserFocus';
  * const browserFocus = new BrowserFocus({ a11y });
  */
+
 import Adapt from 'core/js/adapt';
 
 /**

--- a/js/a11y/deprecated.js
+++ b/js/a11y/deprecated.js
@@ -1,9 +1,43 @@
+/**
+ * @file Deprecated A11y API - Backward compatibility shims for legacy jQuery methods
+ * @module core/js/a11y/deprecated
+ * @description Provides backward compatibility by mapping deprecated jQuery accessibility
+ * methods to the new A11y module API. All deprecated methods log warnings directing
+ * developers to the modern replacements.
+ *
+ * **Method Categories:**
+ * - **Removed**: Methods that no longer serve a purpose (log removal notice, return stub)
+ * - **Deprecated**: Methods that map to new API equivalents (log warning, call new API)
+ *
+ * **jQuery Instance Methods ($.fn):**
+ * - `a11y_on` → `a11y.findTabbable()` + `a11y.toggleAccessible()`
+ * - `a11y_popup` → `a11y.popupOpened()`
+ * - `a11y_cntrl` → `a11y.toggleAccessible()` + `a11y.toggleEnabled()`
+ * - `a11y_cntrl_enabled` → `a11y.toggleAccessibleEnabled()`
+ * - `isReadable` → `a11y.isReadable()`
+ * - `focusNoScroll` → `a11y.focus()`
+ * - `focusNext` → `a11y.focusNext()` or `a11y.findFirstReadable()`
+ * - `focusOrNext` → `a11y.focusFirst()`
+ * - `a11y_focus` → `a11y.focusFirst()`
+ * - `scrollDisable` → `a11y.scrollDisable()`
+ * - `scrollEnable` → `a11y.scrollEnable()`
+ *
+ * **jQuery Static Methods ($):**
+ * - `a11y_on` → `a11y.toggleHidden()`
+ * - `a11y_popdown` → `a11y.popupClosed()`
+ * - `a11y_focus` → `a11y.focusFirst()`
+ * - `a11y_normalize` → `a11y.normalize()`
+ * - `a11y_remove_breaks` → `a11y.removeBreaks()`
+ */
+
+/**
+ * Registers deprecated jQuery methods that map to the new A11y API.
+ * Called during A11y module initialization to maintain backward compatibility.
+ * @param {Object} a11y - The A11y module instance for API delegation and logging
+ */
 export default function(a11y) {
 
-  /**
-   * The old API is rerouted to the new API with warnings.
-   */
-
+  // Extend jQuery prototype with deprecated instance methods
   Object.assign($.fn, {
 
     isFixedPostion() {
@@ -124,6 +158,7 @@ export default function(a11y) {
 
   });
 
+  // Extend jQuery static object with deprecated static methods
   Object.assign($, {
 
     a11y_alert() {

--- a/js/a11y/focusOptions.js
+++ b/js/a11y/focusOptions.js
@@ -1,23 +1,41 @@
+/**
+ * @file Focus Options - Configuration object for A11y focus methods
+ * @module core/js/a11y/focusOptions
+ * @description Provides a standardized options container for focus-related methods
+ * in the A11y module.
+ * Encapsulates scroll prevention and deferred focus settings.
+ *
+ * @example
+ * import FocusOptions from 'core/js/a11y/focusOptions';
+ *
+ * const options = new FocusOptions({ preventScroll: true, defer: true });
+ * a11y.focus(element, options);
+ */
+
+/**
+ * @class FocusOptions
+ * @classdesc Configuration container for A11y focus method options.
+ */
 export default class FocusOptions {
 
   /**
-   * Options parser for focus functions.
-   * @param {Object} options
-   * @param {boolean} [options.preventScroll=false] Stops the browser from scrolling to the focused point. https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
-   * @param {boolean} [options.defer=false] Add a defer to the focus call, allowing for user interface settling.
+   * Creates a FocusOptions instance with normalized default values.
+   * @param {Object} [options={}] - Focus configuration options
+   * @param {boolean} [options.preventScroll=false] - Prevents browser scrolling to focused element
+   * @param {boolean} [options.defer=false] - Defers focus call to allow UI settling
    */
   constructor({
     preventScroll = false,
     defer = false
   } = {}) {
     /**
-    * Stops the browser from scrolling to the focused point.
-    * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
-    * @type {boolean}
-    */
+     * Prevents browser scrolling to focused element.
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus|MDN HTMLElement.focus()}
+     * @type {boolean}
+     */
     this.preventScroll = preventScroll;
     /**
-     * Add a defer to the focus call, allowing for user interface settling.
+     * Defers the focus call, allowing UI to settle.
      * @type {boolean}
      */
     this.defer = defer;

--- a/js/a11y/keyboardFocusOutline.js
+++ b/js/a11y/keyboardFocusOutline.js
@@ -1,12 +1,36 @@
+/**
+ * @file Keyboard Focus Outline - Input method-aware focus outline management
+ * @module core/js/a11y/keyboardFocusOutline
+ * @description Controls focus outline visibility based on user input method.
+ * Hides focus outlines for mouse users while preserving them for keyboard navigation,
+ * improving visual aesthetics without sacrificing accessibility.
+ *
+ * **Behavior Modes:**
+ * - **Keyboard-only outlines**: Hidden by default, shown when navigation keys pressed
+ * - **Disabled outlines**: Focus outlines completely removed (not recommended)
+ * - **Default**: Focus outlines always visible
+ *
+ * **Trigger Keys:** Tab, Enter, Space, Arrow keys
+ *
+ * @example
+ * import KeyboardFocusOutline from 'core/js/a11y/keyboardFocusOutline';
+ * const focusOutline = new KeyboardFocusOutline({ a11y });
+ */
 import Adapt from 'core/js/adapt';
 
 /**
- * Manages whether or not the focus outline should be entirely removed
- * or removed until a key is pressed on a tabbable element.
- * @class
+ * @class KeyboardFocusOutline
+ * @classdesc Toggles focus outline visibility based on keyboard vs mouse input.
+ * @extends Backbone.Controller
  */
 export default class KeyboardFocusOutline extends Backbone.Controller {
 
+  /**
+   * Initializes the keyboard focus outline controller.
+   * Binds event handler, caches HTML element, and defines trigger key map.
+   * @param {Object} options - Configuration options
+   * @param {Object} options.a11y - Reference to the parent A11y module instance
+   */
   initialize({ a11y }) {
     this.a11y = a11y;
     this._onKeyDown = this._onKeyDown.bind(this);
@@ -25,13 +49,19 @@ export default class KeyboardFocusOutline extends Backbone.Controller {
     });
   }
 
+  /**
+   * Attaches keydown listener and applies initial styling.
+   * @private
+   */
   _attachEventListeners() {
     document.addEventListener('keydown', this._onKeyDown);
     this._start();
   }
 
   /**
-   * Add styling classes if required.
+   * Applies initial focus outline styling based on configuration.
+   * Adds `a11y-disable-focusoutline` class if outlines should be hidden.
+   * @private
    */
   _start() {
     const config = this.a11y.config;
@@ -46,9 +76,11 @@ export default class KeyboardFocusOutline extends Backbone.Controller {
   }
 
   /**
-   * Handle key down events for on a tabbable element.
-   *
-   * @param {JQuery.Event} event
+   * Handles keydown events to show focus outline on keyboard navigation.
+   * Removes `a11y-disable-focusoutline` class when a trigger key is pressed
+   * on a tabbable element that isn't in the ignore list.
+   * @param {KeyboardEvent} event - The keydown event
+   * @private
    */
   _onKeyDown(event) {
     const config = this.a11y.config;

--- a/js/a11y/keyboardFocusOutline.js
+++ b/js/a11y/keyboardFocusOutline.js
@@ -25,12 +25,6 @@ import Adapt from 'core/js/adapt';
  */
 export default class KeyboardFocusOutline extends Backbone.Controller {
 
-  /**
-   * Initializes the keyboard focus outline controller.
-   * Binds event handler, caches HTML element, and defines trigger key map.
-   * @param {Object} options - Configuration options
-   * @param {Object} options.a11y - Reference to the parent A11y module instance
-   */
   initialize({ a11y }) {
     this.a11y = a11y;
     this._onKeyDown = this._onKeyDown.bind(this);
@@ -49,10 +43,6 @@ export default class KeyboardFocusOutline extends Backbone.Controller {
     });
   }
 
-  /**
-   * Attaches keydown listener and applies initial styling.
-   * @private
-   */
   _attachEventListeners() {
     document.addEventListener('keydown', this._onKeyDown);
     this._start();

--- a/js/a11y/log.js
+++ b/js/a11y/log.js
@@ -1,8 +1,17 @@
+/**
+ * @file Log - Accessibility logging controller for removed and deprecated API warnings
+ * @module core/js/a11y/log
+ * @description Provides methods to log warnings about removed or deprecated API
+ * features with configurable behavior including filtering duplicate warnings
+ * and enabling/disabling warnings globally.
+*/
+
 import logging from 'core/js/logging';
 
 /**
- * Controller for managing accessibilty logging, specifically used for
- * controlling the display of removed or deprecated API warnings.
+ * @class Log
+ * @classdesc Manages logging of accessibility related warnings for removed and deprecated API features.
+ * @extends Backbone.Controller
  */
 export default class Log extends Backbone.Controller {
 
@@ -11,6 +20,15 @@ export default class Log extends Backbone.Controller {
     this._warned = {};
   }
 
+  /**
+   * Checks if a warning has already been issued for the given arguments.
+   * Uses a hash of the arguments to track whether a warning has been shown before.
+   * Only tracks warnings if the `_warnFirstOnly` configuration option is enabled.
+   * @private
+   * @param {Array} args - Arguments to create a hash from for tracking
+   * @returns {boolean} True if warning has already been shown (and _warnFirstOnly is enabled),
+   *                    false otherwise
+   */
   _hasWarned(args) {
     const config = this.a11y.config;
     if (!config._options._warnFirstOnly) {
@@ -29,6 +47,16 @@ export default class Log extends Backbone.Controller {
     return Boolean(config._options._warn);
   }
 
+  /**
+   * Logs a warning about a removed API feature.
+   * Checks if warnings are enabled and if this specific warning has already been
+   * logged. If conditions are met, delegates to the logging module to output
+   * the removed API warning.
+   * @param {...*} args - Arguments to pass to the logging.removed method.
+   *                      First argument is typically the API name or description.
+   * @returns {Log|undefined} Returns 'this' for method chaining if warning is logged,
+   *                          undefined if warnings are disabled or already shown
+   */
   removed(...args) {
     if (!this._canWarn) {
       return;
@@ -41,6 +69,16 @@ export default class Log extends Backbone.Controller {
     return this;
   }
 
+  /**
+   * Logs a warning about a deprecated API feature.
+   * Checks if warnings are enabled and if this specific warning has already been
+   * logged. If conditions are met, delegates to the logging module to output
+   * the deprecated API warning.
+   * @param {...*} args - Arguments to pass to the logging.deprecated method.
+   *                      First argument is typically the deprecated API name or description.
+   * @returns {Log|undefined} Returns 'this' for method chaining if warning is logged,
+   *                          undefined if warnings are disabled or already shown
+   */
   deprecated(...args) {
     if (!this._canWarn) {
       return;

--- a/js/a11y/popup.js
+++ b/js/a11y/popup.js
@@ -1,43 +1,67 @@
+/**
+ * @file Popup - Popup accessibility manager
+ * @module core/js/a11y/popup
+ * @description Manages focus containment, tabindex and aria-hidden attributes for
+ * modal popups. Supports native dialog elements and custom popup implementations,
+ * preserving and restoring accessibility attributes when popups are opened and closed.
+ *
+ * **Features:**
+ * - Stack-based management for multiple nested popups
+ * - Automatic focus restoration to previously active element
+ * - Supports native HTML dialog elements with showModal()
+ * - Provides unique identifiers for DOM elements to track attribute state
+ * - Backward compatibility with legacy 'popup:opened' and 'popup:closed' events
+ */
+
 import Adapt from 'core/js/adapt';
 import logging from '../logging';
 import wait from 'core/js/wait';
 
 /**
- * Tabindex and aria-hidden manager for popups.
- * @class
+ * @class Popup
+ * @classdesc Manages accessibility for modal popups, including focus containment and attribute management.
+ * @extends Backbone.Controller
  */
 export default class Popup extends Backbone.Controller {
 
+  /**
+   * Initializes the Popup controller with accessibility configuration.
+   * Sets up the stack-based system for managing popups, including focus tracking,
+   * tabindex management, and aria-hidden state preservation.
+   * Listens to legacy 'popup:opened' and 'popup:closed' events for backward compatibility,
+   * logging deprecation warnings when used.
+   * @param {Object} options - Configuration options
+   * @param {Object} options.a11y - The accessibility module instance
+   *
+   * @returns {void}
+   */
   initialize({ a11y }) {
     this.a11y = a11y;
     /**
-     * List of elements which form the base at which elements are generally tabbale
+     * List of elements which form the base at which elements are generally tabbable
      * and aria-hidden='false'.
-     *
      * @type {Array<Object>}
      */
     this._floorStack = [$('body')];
     /**
      * List of elements to return the focus to once leaving each stack.
-     *
      * @type {Array<Object>}
      */
     this._focusStack = [];
     /**
      * Hash of tabindex states for each tabbable element in the popup stack.
-     *
      * @type {Object}
      */
     this._tabIndexes = {};
     /**
      * Hash of aria-hidden states for each tabbable element in the popup stack.
-     *
      * @type {Object}
      */
     this._ariaHiddens = {};
     /**
      * Incremented unique ids for elements belonging to a popup stack with saved
-     * states,
+     * states.
+     * @type {number}
      */
     this._elementUIDIndex = 0;
     this.listenTo(Adapt, {
@@ -67,14 +91,16 @@ export default class Popup extends Backbone.Controller {
   }
 
   /**
-   * Reorganise the tabindex and aria-hidden attributes in the document to
-   * restrict user interaction to the element specified.
-   *
-   * @param {Object} [$popupElement] Element encapulating the popup.
-   * @returns {Object} Returns `a11y._popup`.
+   * Opens a popup and reorganizes tabindex and aria-hidden attributes to
+   * restrict user interaction to the specified element.
+   * Adds the popup to the stack, saves the currently active element for later focus
+   * restoration, and triggers a global 'popup:opened' event (unless silent mode is enabled).
+   * @param {jQuery|HTMLElement} [$popupElement] - Element encapsulating the popup.
+   *                                               Defaults to the currently active element.
+   * @param {boolean} [silent=false] - If true, suppresses the 'popup:opened' event trigger.
+   * @returns {Popup} Returns this for method chaining.
    */
   opened($popupElement, silent) {
-    // Capture currently active element or element specified
     $popupElement = $popupElement || $(document.activeElement);
     this._addPopupLayer($popupElement);
     if (!silent) {
@@ -84,9 +110,16 @@ export default class Popup extends Backbone.Controller {
   }
 
   /**
-   * Restrict tabbing and screen reader access to selected element only.
-   *
-   * @param {Object} $popupElement Element encapulating the popup.
+   * Restricts tabbing and screen reader access to the specified popup element.
+   * Adds a new layer to the popup stack and saves the current focus. For HTML dialog
+   * elements, directly uses the native showModal() API. For other elements, manages
+   * tabindex and aria-hidden attributes on sibling and ancestor elements to isolate
+   * the popup from the rest of the document.
+   * Stores original attribute values using unique element IDs for restoration when
+   * the popup is closed.
+   * @private
+   * @param {jQuery|HTMLElement} $popupElement - Element encapsulating the popup.
+   * @returns {jQuery} Returns the popup element as a jQuery object.
    */
   _addPopupLayer($popupElement) {
     $popupElement = $($popupElement);
@@ -144,11 +177,14 @@ export default class Popup extends Backbone.Controller {
   }
 
   /**
-   * Close the last popup on the stack, restoring tabindex and aria-hidden
-   * attributes.
-   *
-   * @param {Object} [$forceFocusElement] Element at which to move focus.
-   * @returns {Object} Returns `a11y._popup`.
+   * Closes the last popup on the stack and restores tabindex and aria-hidden attributes
+   * to the specified element or the previously active element.
+   * Triggers 'popup:closing' and 'popup:closed' events (unless silent mode is enabled).
+   * @async
+   * @param {jQuery|HTMLElement} [$forceFocusElement] - Element to receive focus after popup closes.
+   *                                                    Defaults to the previously focused element.
+   * @param {boolean} [silent=false] - If true, suppresses the 'popup:closing' and 'popup:closed' event triggers.
+   * @returns {Promise<Popup>} Returns a promise that resolves to this for method chaining.
    */
   async closed($forceFocusElement, silent) {
     if (!silent) {
@@ -167,8 +203,12 @@ export default class Popup extends Backbone.Controller {
   /**
    * Restores tabbing and screen reader access to the state before the last
    * `_addPopupLayer` call.
-   *
-   * @returns {Object} Returns previously active element.
+   * Removes the topmost popup from the stack and restores the original tabindex and
+   * aria-hidden attribute values for all affected elements. For native dialog elements,
+   * closes them using the dialog.close() API.
+   * @private
+   * @returns {jQuery|undefined} Returns the previously active element as a jQuery object,
+   *                            or undefined if no popup was open.
    */
   _removeLastPopupLayer() {
     // the body layer is the first element and must always exist
@@ -226,11 +266,10 @@ export default class Popup extends Backbone.Controller {
   }
 
   /**
-   * When a popup is open, this function makes it possible to swap the element
-   * that should receive focus on popup close.
-   *
-   * @param {Object} $focusElement Set a new element to focus on.
-   * @returns {Object} Returns previously set focus element.
+   * Changes which element should receive focus when the current popup is closed.
+   * @param {jQuery|HTMLElement} $focusElement - Element that should receive focus when closing.
+   * @returns {jQuery|undefined} Returns the previously set focus element,
+   *                            or undefined if no popup was open.
    */
   setCloseTo($focusElement) {
     const $original = this._focusStack.pop();

--- a/js/a11y/scroll.js
+++ b/js/a11y/scroll.js
@@ -1,9 +1,27 @@
 /**
- * Controller for blocking scroll events on specified elements.
- * @class
+ * @file Scroll - Controller for managing scrolling behavior
+ * @module core/js/a11y/scroll
+ * @description Manages scrolling behavior across multiple input methods including touch, mouse wheel,
+ * and keyboard navigation. Supports selective scroll disabling on specified elements while allowing
+ * scrolling in other regions. Handles various edge cases including multi-touch gestures,
+ * nested scrollable elements, and accessible form inputs.
+ */
+
+/**
+ * @class Scroll
+ * @classdesc Manages scroll event blocking on specified elements for accessibility purposes.
+ * @extends Backbone.Controller
  */
 export default class Scroll extends Backbone.Controller {
 
+  /**
+   * Sets up event listeners for touch, wheel, and keyboard scroll events across the document
+   * and window. Configures key codes for scroll-preventing keys (Page Up/Down, Home/End, Arrow keys)
+   * and establishes exclusion selectors for form elements that should allow keyboard interaction.
+   * @param {Object} options - Configuration options
+   * @param {Object} options.a11y - The accessibility module instance
+   * @returns {void}
+   */
   initialize({ a11y }) {
     this._a11y = a11y;
     this._onTouchStart = this._onTouchStart.bind(this);
@@ -42,8 +60,10 @@ export default class Scroll extends Backbone.Controller {
 
   /**
    * Block scrolling on the given elements.
-   *
-   * @param {Object|string|Array} $elements
+   * Adds elements to the collection of scroll-disabled elements. Activates scroll event
+   * listeners if this is the first disabled element.
+   * @param {jQuery|string|Array|HTMLElement} $elements - Element(s) to disable scrolling on
+   * @returns {Scroll} Returns this for method chaining.
    */
   disable($elements) {
     $elements = $($elements);
@@ -54,8 +74,10 @@ export default class Scroll extends Backbone.Controller {
 
   /**
    * Stop blocking scrolling on the given elements.
-   *
-   * @param {Object|string|Array} $items
+   * Removes elements from the collection of scroll-disabled elements. If no elements remain
+   * disabled, deactivates scroll event listeners.
+   * @param {jQuery|string|Array|HTMLElement} $elements - Element(s) to re-enable scrolling on
+   * @returns {Scroll} Returns this for method chaining.
    */
   enable($elements) {
     $elements = $($elements);
@@ -69,7 +91,8 @@ export default class Scroll extends Backbone.Controller {
   }
 
   /**
-   * Stop blocking all scrolling.
+   * Clears all scroll-disabled elements and deactivates scroll event listeners.
+   * @returns {Scroll} Returns this for method chaining.
    */
   clear() {
     this._scrollDisabledElements = $([]);
@@ -78,7 +101,11 @@ export default class Scroll extends Backbone.Controller {
   }
 
   /**
-   * Start or stop listening for events to block if and when needed.
+   * Starts or stops listening for scroll events based on disabled element count.
+   * Activates scroll event listeners if there are disabled elements, or deactivates them
+   * if the disabled collection is empty.
+   * @private
+   * @returns {void}
    */
   _checkRunning() {
     if (!this._scrollDisabledElements.length) {
@@ -90,6 +117,8 @@ export default class Scroll extends Backbone.Controller {
 
   /**
    * Start listening for events to block.
+   * @private
+   * @returns {void}
    */
   _start() {
     if (this._isRunning) {
@@ -99,9 +128,12 @@ export default class Scroll extends Backbone.Controller {
   }
 
   /**
-   * Capture the touchstart event object for deltaY calculations.
-   *
-   * @param {JQuery.Event} event
+   * Captures the touchstart event object for deltaY calculations.
+   * Stores the initial touch position to later calculate the direction and distance
+   * of touch movement for scroll prevention.
+   * @private
+   * @param {Event} event - The native touch start event
+   * @returns {boolean} Returns true
    */
   _onTouchStart(event) {
     if (!this._isRunning) return;
@@ -111,7 +143,10 @@ export default class Scroll extends Backbone.Controller {
   }
 
   /**
-   * Clear touchstart event object.
+   * Clears the touchstart event object.
+   * Resets the stored touch start position after the touch ends.
+   * @private
+   * @returns {boolean} Returns true
    */
   _onTouchEnd() {
     if (!this._isRunning) return;
@@ -120,9 +155,11 @@ export default class Scroll extends Backbone.Controller {
   }
 
   /**
-   * Process a native scroll event.
-   *
-   * @param {JQuery.Event} event
+   * Processes a native scroll event (wheel or touch movement).
+   * Delegates to `_preventScroll` to determine if scrolling should be blocked.
+   * @private
+   * @param {Event} event - The native wheel or touch move event
+   * @returns {*} Result from `_preventScroll` (false if blocked, undefined otherwise)
    */
   _onScrollEvent(event) {
     if (!this._isRunning) return;
@@ -131,9 +168,13 @@ export default class Scroll extends Backbone.Controller {
   }
 
   /**
-   * Process a native keydown event.
-   *
-   * @param {JQuery.Event} event
+   * Processes a native keydown event to prevent scroll-related keyboard navigation.
+   * Handles arrow keys (when accessible navigation is enabled) and scroll-trigger keys
+   * (Page Up/Down, Home/End, arrow keys). Redirects focus to the first scrollable element
+   * in an open popup when appropriate. Excludes form elements that should accept keyboard input.
+   * @private
+   * @param {Event} event - The native keydown event
+   * @returns {*} Result from `_preventScroll` if key should be blocked, undefined otherwise
    */
   _onKeyDown(event) {
     if (!this._isRunning) return;
@@ -162,9 +203,13 @@ export default class Scroll extends Backbone.Controller {
   }
 
   /**
-   * Process jquery event object.
-   *
-   * @param {JQuery.Event} event
+   * Prevents scroll on the target element if it's in the disabled collection.
+   * Checks if the scroll target is within a disabled element. Handles multi-touch gestures
+   * by allowing them through. For single-touch/wheel scrolls, prevents default behavior
+   * and returns false if the scroll target is disabled.
+   * @private
+   * @param {Event} event - The scroll event (wheel, touch, or keyboard)
+   * @returns {boolean|undefined} Returns false if scroll is prevented, undefined otherwise
    */
   _preventScroll(event) {
     const isGesture = (event.touches?.length > 1);
@@ -187,10 +232,13 @@ export default class Scroll extends Backbone.Controller {
   }
 
   /**
-   * Return the parent which will be scrolling from the current scroll event.
-   *
-   * @param {JQuery.Event} event
-   * @param {Object} $target jQuery element object.
+   * Determines which parent element will handle the scroll event.
+   * Considers scroll direction (up/down) and whether the parent has available scroll space.
+   * Returns the body element if no scrollable parent is found.
+   * @private
+   * @param {Event} event - The scroll event
+   * @param {jQuery} $target - The target element where scroll event originated
+   * @returns {jQuery} The parent element that will handle the scroll
    */
   _getScrollingParent(event, $target) {
     const isTouchEvent = event.type === 'touchmove';
@@ -222,10 +270,12 @@ export default class Scroll extends Backbone.Controller {
   }
 
   /**
-   * Returns true if the specified target is scrollable.
-   *
-   * @param {Object} $target jQuery element object.
-   * @returns {boolean}
+   * Checks if the specified element is scrollable.
+   * An element is scrollable if it has `overflow-y` set to 'auto' or 'scroll' and
+   * has `pointer-events` enabled (not 'none').
+   * @private
+   * @param {jQuery} $target - The element to check
+   * @returns {boolean} True if element is scrollable, false otherwise
    */
   _isScrollable($target) {
     const scrollType = $target.css('overflow-y');
@@ -240,12 +290,13 @@ export default class Scroll extends Backbone.Controller {
   }
 
   /**
-   * Returns true if the specified target is the scrolling target.
-   *
-   * @param {Object} $target jQuery element object.
-   * @param {string} directionY 'none' | 'up' | 'down'
-   *
-   * @returns {boolean}
+   * Checks if the specified element has available scroll space in the given direction.
+   * Compares the current scroll position and viewport height against the total scroll height
+   * to determine if there's room to scroll in the specified direction.
+   * @private
+   * @param {jQuery} $target - The element to check
+   * @param {string} directionY - Scroll direction: 'none' | 'up' | 'down'
+   * @returns {boolean} True if element can scroll in the given direction, false otherwise
    */
   _isScrolling($target, directionY) {
     const scrollTop = Math.ceil($target.scrollTop());
@@ -270,10 +321,12 @@ export default class Scroll extends Backbone.Controller {
   }
 
   /**
-   * Returns the vertical direction of scroll.
-   *
-   * @param {JQuery.Event} event
-   * @returns {string} 'none' | 'up' | 'down'
+   * Determines the vertical direction of scroll from an event.
+   * Calculates scroll direction based on the deltaY value. Positive values indicate
+   * scrolling up, negative values indicate scrolling down.
+   * @private
+   * @param {Event} event - The scroll event
+   * @returns {string} Scroll direction: 'none' | 'up' | 'down'
    */
   _getScrollDirection(event) {
     const deltaY = this._getScrollDelta(event);
@@ -284,10 +337,15 @@ export default class Scroll extends Backbone.Controller {
   }
 
   /**
-   * Returns the number of pixels which is intended to be scrolled.
-   *
-   * @param {JQuery.Event} event
-   * @returns {number}
+   * Calculates the scroll delta (distance) from a scroll event.
+   * Handles different input methods:
+   * - Touch events: calculates delta from touchstart position to current touch position
+   * - Keyboard events: returns 1 or -1 based on scroll-trigger key
+   * - Mouse wheel: extracts delta from wheelDeltaY or deltaY properties
+   * Accounts for cross-browser differences (Firefox/IE delta inversion, Chrome/Safari wheel delta).
+   * @private
+   * @param {Event} event - The scroll event
+   * @returns {number} Pixel delta value (positive = up, negative = down)
    */
   _getScrollDelta(event) {
     let deltaY = 0;
@@ -328,7 +386,10 @@ export default class Scroll extends Backbone.Controller {
   }
 
   /**
-   * Stop listening for events to block.
+   * Deactivates the scroll event listener.
+   * Sets the running flag to false, disabling scroll event processing.
+   * @private
+   * @returns {void}
    */
   _stop() {
     if (!this._isRunning) {

--- a/js/a11y/topOfContentObject.js
+++ b/js/a11y/topOfContentObject.js
@@ -1,3 +1,11 @@
+/**
+ * @file Top of Content Object - Manages focus target for content object transitions.
+ * @module core/js/a11y/topOfContentObject
+ * @description Manages a visually hidden element that serves as a focus target when entering
+ * new content objects (page or menu). Supports accessibility by providing screen reader users with
+ * clear context about page transitions and enabling keyboard navigation to the top of new content.
+ */
+
 import Adapt from 'core/js/adapt';
 
 const DEFAULT_TYPE_LABEL = {
@@ -7,11 +15,22 @@ const DEFAULT_TYPE_LABEL = {
 };
 
 /**
- * Add element to focus when entering a new content object
- * @class
+ * @class TopOfContentObject
+ * @classdesc Manages keyboard focus and screen reader announcements when entering
+ * new pages or menus. Displays context like "Page Introduction" or "Sub menu Activities"
+ * in a visually hidden element at the top of the page.
+ * @extends {Backbone.Controller}
  */
 export default class TopOfContentObject extends Backbone.Controller {
 
+  /**
+   * Sets up event listeners for accessibility readiness and router navigation.
+   * When accessibility is ready, creates the top-of-content element. When route
+   * location changes, updates the element with the new page/menu information.
+   * @param {Object} options - Configuration options
+   * @param {Object} options.a11y - The accessibility module instance
+   * @returns {void}
+   */
   initialize({ a11y }) {
     this.a11y = a11y;
     this.$body = $('body');
@@ -21,6 +40,14 @@ export default class TopOfContentObject extends Backbone.Controller {
     });
   }
 
+  /**
+   * Creates a div element with id "a11y-topofcontentobject" that is:
+   * - Hidden visually with the "visually-hidden" class
+   * - Focusable via tabindex="-1" (programmatically focusable only)
+   * - Positioned at the beginning of the page body
+   * Only creates the element if accessibility is enabled and popup management is configured.
+   * @returns {void}
+   */
   createElement() {
     const config = this.a11y.config;
     if (!config._isEnabled || !config._options._isPopupManagementEnabled) return;
@@ -28,6 +55,22 @@ export default class TopOfContentObject extends Backbone.Controller {
     this.$body.prepend(this.$element);
   }
 
+  /**
+   * Updates the top-of-content element with current page/menu information.
+   * Extracts the current content model's type and title, normalizes the text for
+   * accessibility, and renders the element's content using a Handlebars template
+   * from the accessibility configuration. The template typically outputs text like
+   * "Page My Page Title" or "Sub menu My Menu Title".
+   * Uses global accessibility labels and falls back to DEFAULT_TYPE_LABEL if custom
+   * labels are not configured. Only updates if accessibility is enabled and popup
+   * management is configured.
+   * @param {Object} location - Router location object containing current content model
+   * @param {Object} location._currentModel - The current Adapt content model (page, menu, or course)
+   * @returns {void}
+   * @example
+   * // Automatically called when router:location event fires
+   * // Updates element text: <div>Page Introduction to Course</div>
+   */
   updateElement(location) {
     const config = this.a11y.config;
     if (!config._isEnabled || !config._options._isPopupManagementEnabled) return;
@@ -40,6 +83,17 @@ export default class TopOfContentObject extends Backbone.Controller {
     this.$element.html(template(json));
   }
 
+  /**
+   * Sets focus to the top-of-content element.
+   * Typically causes screen readers to announce the current page/menu information. Useful
+   * for keyboard navigation when entering a new page or menu.
+   * Only focuses the element if accessibility is enabled, popup management is configured,
+   * and the element is not already focused.
+   * @returns {void}
+   * @example
+   * a11y.topOfContentObject.goto();
+   * // Screen reader announces: "Page Introduction to Course"
+   */
   goto() {
     const config = this.a11y.config;
     if (!config._isEnabled || !config._options._isPopupManagementEnabled) return;

--- a/js/a11y/wrapFocus.js
+++ b/js/a11y/wrapFocus.js
@@ -1,8 +1,21 @@
+/**
+ * @file Wrap Focus - Manages focus wrapping for keyboard navigation in popups.
+ * @module core/js/a11y/wrapFocus
+ * @description Prevents tab focus from escaping popup elements by detecting when focus
+ * reaches the end of focusable content. Uses guard elements (marked with the
+ * focusguard class) to detect when keyboard users try to tab out of the popup,
+ * and redirects focus to the top of the accessible content.
+ * Supports both click and focus events to handle different browser behaviors
+ * and keyboard/mouse navigation patterns.
+ */
 import Adapt from 'core/js/adapt';
 
 /**
- * Controller for managing tab wrapping for popups.
- * @class
+ * @class WrapFocus
+ * @classdesc Implements focus wrapping for popups by detecting when focus reaches
+ * guard elements at popup boundaries and resetting focus to the top of the document.
+ * Improves accessibility by keeping keyboard users within modal popups.
+ * @extends {Backbone.Controller}
  */
 export default class WrapFocus extends Backbone.Controller {
 
@@ -14,16 +27,32 @@ export default class WrapFocus extends Backbone.Controller {
     });
   }
 
+  /**
+   * Attaches click and focus event listeners to focusguard elements.
+   * @private
+   * @returns {void}
+   * @example
+   * // Called automatically when accessibility:ready event fires
+   * // Listens for click/focus on elements with focusguard class
+   */
   _attachEventListeners() {
     const config = this.a11y.config;
     $('body').on('click focus', config._options._focusguard, this._onWrapAround);
   }
 
   /**
-   * If click or focus is received on any element with the focusguard class,
-   * loop focus around to the top of the document.
-   *
-   * @param {JQuery.Event} event
+   * Wraps focus around when focus reaches a guard element.
+   * Handles click or focus events on focusguard elements by preventing the event
+   * and resetting focus to the first focusable element at the top of the document.
+   * This keeps keyboard focus contained within the popup or modal dialog.
+   * Only executes focus wrapping if focus wrapping is enabled and accessibility
+   * is configured. Handles both prevent behavior (stop event propagation and default action).
+   * @private
+   * @param {Event} event - The click or focus event triggered on a focusguard element
+   * @returns {void}
+   * @example
+   * // User tabs to the end of popup content and reaches guard element
+   * // Focus automatically wrapped back to first focusable element in popup
    */
   _onWrapAround(event) {
     const config = this.a11y.config;

--- a/js/fixes/safari.label.click.blur.js
+++ b/js/fixes/safari.label.click.blur.js
@@ -51,7 +51,7 @@ function onLabelClick (event) {
   const input = document.querySelector(`[id="${event.currentTarget.getAttribute('for')}"]`);
   if (!input) return;
   event.preventDefault();
-  // focus first so that jaws doesn't jump scroll to the top
+  // focus first so that JAWS doesn't jump scroll to the top
   input.focus();
   input.click();
 };

--- a/js/fixes/safari.label.click.blur.js
+++ b/js/fixes/safari.label.click.blur.js
@@ -1,19 +1,28 @@
+/**
+ * @file Safari Label Click Blur Fix - Handles label-input interaction quirks in Safari
+ * @module core/js/fixes/safari.label.click.blur
+ * @description Utility module that fixes a Safari specific issue where template rerenders
+ * on blur events prevent click events from firing when clicking label elements.
+ * When enabled, intercepts label clicks and manually triggers clicks on associated input
+ * elements via the label's `for` attribute. Applies to both iOS Safari and macOS Safari.
+ *
+ * **Problem:**
+ * Safari's event sequence differs from Chrome/Firefox: it fires mousedown → blur → mouseup → focus → click.
+ * When a blur triggers template rerender, the DOM mutation prevents the subsequent click event
+ * from firing on the input element. This breaks form interactions and accessibility patterns.
+ *
+ * **Solution:**
+ * Prevent default label click behavior and manually focus and click the target input element.
+ * This ensures the click event fires and the input processes the interaction correctly.
+ *
+ * **References:**
+ * - https://www.eventbrite.com/engineering/a-story-of-a-react-re-rendering-bug/
+ * - https://sitr.us/2011/07/28/how-mobile-safari-emulates-mouse-events.html
+ * - https://stackoverflow.com/questions/9335325/blur-event-stops-click-event-from-working
+ */
+
 import Adapt from 'core/js/adapt';
 import 'core/js/templates';
-
-/**
-  In Safari, a click triggers a mousedown, a blur, a mouseup, a focus, then a click,
-  which is different from chrome-based browsers.
-  Sometimes we rerender the template on a blur, the rerender prevents
-  the click event from firing in Safari, instead of allowing click to fall through from
-  the label to the input, we prevent the label click and instead
-  trigger a manual click on the input referenced by the label's for attribute.
-  This fixes the issue in both the iOS and MacOS versions of Safari
-  References:
-    https://www.eventbrite.com/engineering/a-story-of-a-react-re-rendering-bug/
-    https://sitr.us/2011/07/28/how-mobile-safari-emulates-mouse-events.html
-    https://stackoverflow.com/questions/9335325/blur-event-stops-click-event-from-working
- */
 
 Adapt.on('app:dataReady', () => {
   const config = Adapt.config.get('_fixes');
@@ -21,6 +30,23 @@ Adapt.on('app:dataReady', () => {
   applySafariLabelClickBlur();
 });
 
+/**
+ * Handles click events on label elements by manually triggering the associated input click.
+ * Replaces the default label-to-input click delegation with manual event handling.
+ * This prevents issues where template rerenders on blur cancel the subsequent click event.
+ * First focuses the input (for proper screen reader announcements in JAWS, preventing
+ * unwanted scroll-to-top), then clicks it. If the label's `for` attribute doesn't reference
+ * a valid input element, silently returns without error.
+ * @private
+ * @param {MouseEvent} event - Click event from the label element
+ * @returns {void}
+ * @example
+ * // Called internally when user clicks a label
+ * // Automatically focuses and clicks the associated input
+ * const input = document.querySelector('[id="checkbox-1"]');
+ * input.focus();  // Announce to screen readers
+ * input.click();  // Trigger input handler
+ */
 function onLabelClick (event) {
   const input = document.querySelector(`[id="${event.currentTarget.getAttribute('for')}"]`);
   if (!input) return;
@@ -30,6 +56,19 @@ function onLabelClick (event) {
   input.click();
 };
 
+/**
+ * Applies the Safari label-input click fix to React component render pipeline.
+ * Intercepts the React pre-render phase ('reactElement:preRender' event) to inject
+ * click handlers on label elements before they're mounted to the DOM. Only adds the
+ * click handler if:
+ * - Element is a `<label>` tag
+ * - Element has an `htmlFor` attribute (references an input)
+ * - Element doesn't already have an `onClick` handler (prevents override)
+ * This ensures the fix applies to all dynamically rendered labels in the course
+ * without requiring manual intervention or wrapper components.
+ * @private
+ * @returns {void}
+ */
 function applySafariLabelClickBlur () {
   Adapt.on('reactElement:preRender', event => {
     const [tagName, props] = event.args;


### PR DESCRIPTION
### Update
- Fixes #829  
- Adds JSDoc documentation comments to core a11y files:
  - Includes file-level documentation explaining architecture and usage patterns 
  - Documents public methods with parameter types, return values, and examples
- Update ariaDisabled.js `@Class` for consistency with the filename and module purpose

### Testing

1. Open any of the following files in VS Code or another JSDoc-compatible editor:
- a11y.js
- a11y/ariaDisabled.js
- a11y/browserConfig.js
- a11y/browserFocus.js
- a11y/deprecated.js
- a11y/focusOptions.js
- a11y/keyboardFocusOutline.js
- a11y/log.js
- a11y/popup.js
- a11y/scroll.js
- a11y/topOfContentObject.js
- a11y/wrapFocus.js
- fixes/safari.label.click.blur.js

2. Hover over a method name (e.g., a11y.focusFirst) to see the tooltip documentation
3. When calling a method, verify autocomplete suggests parameters with type information