### PR TITLE
Fix Question components marking value is loaded incorrectly on course relaunch (fixes #835)

### DIFF
--- a/js/models/questionModel.js
+++ b/js/models/questionModel.js
@@ -83,6 +83,7 @@ class QuestionModel extends ComponentModel {
     // Not sure this is needed anymore, keeping to maintain API
     this.setupWeightSettings();
     this.setupButtonSettings();
+    this.set('_shouldShowMarking', this.shouldShowMarking);
   }
 
   // Used to setup either global or local button text


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
#835 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* The _showShowMarking variable is applied on launch and not just on submit