### PR TITLE
Fix: Clear selection after programmatic focus to prevent Firefox text selection (fixes #843)

### DIFF
--- a/js/a11y/browserFocus.js
+++ b/js/a11y/browserFocus.js
@@ -71,6 +71,10 @@ export default class BrowserFocus extends Backbone.Controller {
     if (!element) return;
     // refocus on the existing active element to stop jaws from scrolling
     this.a11y.focus(element, { preventScroll: true });
+    // Firefox sets a persistent selection anchor when focus is assigned
+    // programmatically, causing text to be unexpectedly selected on subsequent
+    // clicks. Clear any selection to prevent this.
+    window.getSelection()?.removeAllRanges();
   }
 
   /**


### PR DESCRIPTION
Fixes #843

### Fix
* In `_refocusCurrentActiveElement()`, call `window.getSelection()?.removeAllRanges()` immediately after the programmatic `focus()` call

### Testing
1. Enable `_accessibility._isEnabled: true` in `config.json`
2. Open a page with body text in Firefox
3. Click a focusable element (e.g. a nav button) to give it focus
4. Click on non-focusable body text repeatedly
5. Verify no text is unexpectedly selected

Test in Chrome to confirm no regression.

**JAWS regression check:** The `_refocusCurrentActiveElement()` method being modified was introduced in #697 to prevent JAWS from scrolling when its virtual cursor interacts with grouped elements. `removeAllRanges()` only affects browser text selection state, which JAWS does not use, so regression is unlikely - but if JAWS testing is available, verify focus behaviour on `role=group` elements after this change.

### Root Cause
PR #697 (v6.72.1) added `_refocusCurrentActiveElement()` to handle a JAWS virtual cursor scrolling issue. This method calls `.focus()` programmatically on the previously-active element whenever focus unexpectedly returns to `body`/`html` (via `_onBlur`).

Firefox sets a persistent selection anchor when focus is assigned programmatically. Because `_onBlur` fires between `mousedown` and `mouseup` on every click of non-focusable content, Firefox repositions the selection anchor on each click. The next `mousedown` then extends the selection from that anchor to the new click point.

Calling `removeAllRanges()` immediately after `focus()` clears the anchor before `mouseup` can use it - so no text is selected and there is no visible flash. JAWS is unaffected as it uses its own virtual cursor, not browser text selection state.

---

Posted via collaboration with Claude Code