### PR TITLE
Fix: Preserve user text selection in click handler (fixes #867)

### DIFF
--- a/js/a11y/browserFocus.js
+++ b/js/a11y/browserFocus.js
@@ -62,18 +62,21 @@ export default class BrowserFocus extends Backbone.Controller {
       return;
     }
     const $element = $(event.target);
-    if ($element.is('[data-a11y-force-focus]')) {
+    const finish = () => {
+      const hasFocus = ($element[0] === this.a11y.currentActiveElement);
+      if (hasFocus) return;
+      if (!$element.is('[data-a11y-force-focus]')) return;
       $element.removeAttr('tabindex data-a11y-force-focus');
-    }
+    };
     // From here, only check source elements
     if (event.target !== event.currentTarget) {
-      return;
+      return finish();
     }
     // Do not auto next if the focus isn't returning to the body or html element
     // or if we're not losing focus
     const isNotBodyHTMLOrLostFocus = (!$(event.relatedTarget).is('body, html') && event.relatedTarget !== null);
     if (isNotBodyHTMLOrLostFocus) {
-      return;
+      return finish();
     }
     // Check if element is losing focus
     // due to the addition of a disabled class, display none, visibility hidden,
@@ -84,10 +87,12 @@ export default class BrowserFocus extends Backbone.Controller {
       // This can happen when JAWS screen reader on `role="group"` takes enter click
       // when the focus was on the input element
       this._refocusCurrentActiveElement();
+      finish();
       return;
     }
     // Move focus to next readable element
     this.a11y.focusNext($element);
+    finish();
   }
 
   /**
@@ -120,17 +125,20 @@ export default class BrowserFocus extends Backbone.Controller {
     }
     const $element = $(event.target);
     const $stack = $([...$element.toArray(), ...$element.parents().toArray()]);
-    const $focusable = $stack.filter(config._options._tabbableElements);
+    const $focusable = $stack.filter((i, el) => {
+      const $el = $(el);
+      // Allow label clicks to focus their associated control
+      return $el.is(config._options._tabbableElements) || $el.is('label[for]');
+    });
     if (!$focusable.length) {
       this._refocusCurrentActiveElement();
       return;
     }
-    const $closestFocusable = $element.closest(config._options._tabbableElements);
     // Force focus for screen reader enter / space press
-    if ($closestFocusable[0] !== document.activeElement) {
+    if ($focusable[0] !== document.activeElement) {
       // Focus on the nearest focusable element if not already with focus
       this.a11y._isForcedFocus = true;
-      $closestFocusable[0].focus();
+      $focusable[0].focus();
       this.a11y._isForcedFocus = false;
     }
     if (!config._options._isClickDelayedAfterFocusEnabled) return;

--- a/js/a11y/browserFocus.js
+++ b/js/a11y/browserFocus.js
@@ -101,8 +101,10 @@ export default class BrowserFocus extends Backbone.Controller {
     this.a11y.focus(element, { preventScroll: true });
     // Firefox sets a persistent selection anchor when focus is assigned
     // programmatically, causing text to be unexpectedly selected on subsequent
-    // clicks. Clear any selection to prevent this.
-    window.getSelection()?.removeAllRanges();
+    // clicks. Clear only when the selection is collapsed (a stray anchor with
+    // no range) so genuine user drag-selections are preserved.
+    const selection = window.getSelection();
+    if (selection?.isCollapsed) selection.removeAllRanges();
   }
 
   /**

--- a/js/a11y/browserFocus.js
+++ b/js/a11y/browserFocus.js
@@ -84,6 +84,11 @@ export default class BrowserFocus extends Backbone.Controller {
       // This can happen when JAWS screen reader on `role="group"` takes enter click
       // when the focus was on the input element
       this._refocusCurrentActiveElement();
+      // Firefox sets a persistent selection anchor when focus is assigned
+      // programmatically during blur, causing text to be unexpectedly selected
+      // on subsequent clicks. Clear it here only - the click path must not
+      // touch the selection or it wipes user drag-selections on mouseup.
+      window.getSelection()?.removeAllRanges();
       return;
     }
     // Move focus to next readable element
@@ -99,12 +104,6 @@ export default class BrowserFocus extends Backbone.Controller {
     const element = this.a11y.currentActiveElement;
     if (!element) return;
     this.a11y.focus(element, { preventScroll: true });
-    // Firefox sets a persistent selection anchor when focus is assigned
-    // programmatically, causing text to be unexpectedly selected on subsequent
-    // clicks. Clear only when the selection is collapsed (a stray anchor with
-    // no range) so genuine user drag-selections are preserved.
-    const selection = window.getSelection();
-    if (selection?.isCollapsed) selection.removeAllRanges();
   }
 
   /**

--- a/js/a11y/browserFocus.js
+++ b/js/a11y/browserFocus.js
@@ -138,7 +138,12 @@ export default class BrowserFocus extends Backbone.Controller {
     const $stack = $([...$element.toArray(), ...$element.parents().toArray()]);
     const $focusable = $stack.filter(config._options._tabbableElements);
     if (!$focusable.length) {
-      this._refocusCurrentActiveElement();
+      // Preserve user text selection - refocusing here moves focus away
+      // from the selected text and the browser drops the selection.
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed) {
+        this._refocusCurrentActiveElement();
+      }
       return;
     }
     const $closestFocusable = $element.closest(config._options._tabbableElements);

--- a/js/a11y/browserFocus.js
+++ b/js/a11y/browserFocus.js
@@ -48,9 +48,15 @@ export default class BrowserFocus extends Backbone.Controller {
   _attachEventListeners() {
     this.$body
       .on('blur', '*', this._onBlur)
-      .on('blur', this._onBlur)
+      .on('blur', this._onBlur);
+    // Mouse state is tracked at the document/window level so that a
+    // pointer released outside the body, or focus leaving the window
+    // mid drag, cannot leave _isMouseDown stuck true.
+    $(document)
       .on('mousedown', this._onMouseDown)
-      .on('mouseup', this._onMouseUp);
+      .on('mouseup', this._onMouseUp)
+      .on('mouseleave', this._onMouseUp);
+    $(window).on('blur', this._onMouseUp);
     // 'Capture' event attachment for click
     this.$body[0].addEventListener('click', this._onClick, true);
   }

--- a/js/a11y/browserFocus.js
+++ b/js/a11y/browserFocus.js
@@ -29,6 +29,9 @@ export default class BrowserFocus extends Backbone.Controller {
     this.a11y = a11y;
     this._onBlur = this._onBlur.bind(this);
     this._onClick = this._onClick.bind(this);
+    this._onMouseDown = this._onMouseDown.bind(this);
+    this._onMouseUp = this._onMouseUp.bind(this);
+    this._isMouseDown = false;
     this.$body = $('body');
     this.listenTo(Adapt, {
       'accessibility:ready': this._attachEventListeners
@@ -36,16 +39,28 @@ export default class BrowserFocus extends Backbone.Controller {
   }
 
   /**
-   * Attaches blur and click event listeners to the document body.
+   * Attaches blur, click and mouse tracking event listeners to the document body.
    * Uses event capturing for click to intercept before bubbling.
+   * Mouse state is tracked so that focus is not stolen back to the previously
+   * active element while the user is mid drag-selection.
    * @private
    */
   _attachEventListeners() {
     this.$body
       .on('blur', '*', this._onBlur)
-      .on('blur', this._onBlur);
+      .on('blur', this._onBlur)
+      .on('mousedown', this._onMouseDown)
+      .on('mouseup', this._onMouseUp);
     // 'Capture' event attachment for click
     this.$body[0].addEventListener('click', this._onClick, true);
+  }
+
+  _onMouseDown() {
+    this._isMouseDown = true;
+  }
+
+  _onMouseUp() {
+    this._isMouseDown = false;
   }
 
   /**
@@ -82,13 +97,13 @@ export default class BrowserFocus extends Backbone.Controller {
     if (isNotDisabledHiddenOrDetached) {
       // The element is still available, refocus
       // This can happen when JAWS screen reader on `role="group"` takes enter click
-      // when the focus was on the input element
-      this._refocusCurrentActiveElement();
-      // Firefox sets a persistent selection anchor when focus is assigned
-      // programmatically during blur, causing text to be unexpectedly selected
-      // on subsequent clicks. Clear it here only - the click path must not
-      // touch the selection or it wipes user drag-selections on mouseup.
-      window.getSelection()?.removeAllRanges();
+      // when the focus was on the input element.
+      // Skip while the user is mid drag-selection - stealing focus back during
+      // mousedown sets a programmatic selection anchor (Firefox) and aborts the
+      // in-progress text selection.
+      if (!this._isMouseDown) {
+        this._refocusCurrentActiveElement();
+      }
       return;
     }
     // Move focus to next readable element


### PR DESCRIPTION
Fixes #867

### Fix
The `_refocusCurrentActiveElement()` helper introduced focus stealing during `_onBlur` and `_onClick` flows that broke user text selection in all browsers after #844 landed. This PR replaces the `removeAllRanges()` approach with mouse-state-aware refocus suppression:

* Track `_isMouseDown` via document-level `mousedown`/`mouseup` listeners
* In `_onBlur`, skip the JAWS refocus-on-blur safety net while the user is mid drag-selection
* In `_onClick`, skip the refocus when a non-collapsed selection exists
* Harden the flag against getting stuck true by also resetting on `document.mouseleave` and `window.blur`

### Why this approach
The original Firefox bug (#843) and the new all-browser regression both stem from the same cause: programmatic focus during the mousedown → mouseup window. Firefox plants a stray selection anchor, and every browser drops the active selection when focus moves away from the selected text. Tracking the mouse state lets us leave focus exactly where the user put it during a click/drag, then resume the JAWS safety net once the mouse is released.

`removeAllRanges()` from #844 is no longer required.

### JAWS regression check
JAWS uses a virtual cursor driven from the keyboard — it does not generate `mousedown`/`mouseup`. The `_isMouseDown` flag will never be set during JAWS interaction, so the `role=\"group\"` refocus behaviour from #697 is preserved unchanged.

### Hardening note (document vs body)
The existing blur/click handlers stay on `$body` because they rely on jQuery delegation. The new mousedown/mouseup listeners attach to `document` so a pointer released outside the body (drag off-page, drag to chrome, drag to another iframe) still cycles the flag. `window.blur` and `document.mouseleave` provide additional safety resets if the cleanup `mouseup` is missed entirely. In an iframe these all resolve to the iframe's own document/window, so the scope is correct.

### Testing
1. Enable `_accessibility._isEnabled: true` in `config.json`
2. In Firefox AND Chrome, reload a page with body text
3. Click-drag to select a paragraph - selection should remain after release
4. Triple-click to select a paragraph - selection should remain
5. Confirm copy (Cmd/Ctrl+C) works on the selected text
6. Confirm the original #843 Firefox repro (random clicking on body text) no longer produces phantom selections
7. Tab through focusable elements - focus order unchanged
8. If available: smoke test the matching, slider, and drawer plugins to confirm drag interactions still behave

---

Posted via collaboration with Claude Code