### PR TITLE
Fix: only restore focus on push close when focus was inside the push (fixes #869)

### DIFF
--- a/js/views/notifyPushView.js
+++ b/js/views/notifyPushView.js
@@ -143,7 +143,10 @@ export default class NotifyPushView extends Backbone.View {
       this.$el.removeClass('is-active');
       await transitionsEnded(this.$el);
       this.$el[0].open = false;
-      a11y.gotoPreviousActiveElement();
+      const isFocusInPush = Boolean($(document.activeElement).closest(this.$el).length);
+      if (isFocusInPush) {
+        a11y.gotoPreviousActiveElement();
+      }
       this.model.collection.remove(this.model);
       Adapt.trigger('notify:pushRemoved', this);
       this.model.close();


### PR DESCRIPTION
Fixes #869

### Fix

`notifyPushView.closePush()` now only calls `a11y.gotoPreviousActiveElement()` when focus was actually inside the push element at close time. Push notifications never grab focus on open (non-modal `<dialog>`, `aria-modal=\"false\"`), so an auto-close where the user never tabbed in has no focus contract to restore. The unconditional restore was sending focus to `Adapt.navigation` (navbar) when the previous active element was no longer readable (e.g. a clicked button that was hidden after click) - see #869 for the full repro via `adapt-contrib-trickle` PR #233.

### Testing

1. Apply this branch in your core submodule.
2. Use a course with `adapt-contrib-trickle` configured with `_styleAfterClick: \"hidden\"` (default) on a block, the [issue/232 branch of trickle](https://github.com/adaptlearning/adapt-contrib-trickle/pull/233), and an `additionalContentLoaded` globals message so `notify.read` is called.
3. Click the trickle Continue button via keyboard / screen reader. Confirm: \"Loading\" announce plays, focus does not jump to navbar, focus lands on the next block once content is ready.
4. Re-run the existing push notification interactions you rely on (badges, manual close button, Esc key) and confirm no regressions:
   - Auto-close with no user focus in push - focus stays where it is.
   - User clicks the close button - focus restores via `gotoPreviousActiveElement`.
   - User presses Esc with focus inside the push - focus restores.
   - User clicks the push body (`_openNotifyOnClick`) - separate popup handles its own focus contract.

---

Posted via collaboration with Claude Code