### PR TITLE
New: Add option to display error/fatal messages as on-screen push notifications (fixes #871)

### DIFF
--- a/js/views/notifyView.js
+++ b/js/views/notifyView.js
@@ -22,10 +22,21 @@
 
 import Adapt from 'core/js/adapt';
 import logging from 'core/js/logging';
+import LOG_LEVEL from 'core/js/enums/logLevelEnum';
 import NotifyPushCollection from 'core/js/collections/notifyPushCollection';
 import NotifyPopupView from 'core/js/views/notifyPopupView';
 import NotifyModel from 'core/js/models/notifyModel';
 import a11y from '../a11y';
+
+// Defaults for the optional on-screen notification of logged errors. Merged
+// over any `_logging._notify` config so an older config without the block is
+// safe. Disabled by default so published courses do not surface errors to
+// learners; authors enable it when previewing.
+const NOTIFY_ON_ERROR_DEFAULTS = {
+  _isEnabled: false,
+  _level: 'error',
+  _timeout: 15000
+};
 
 /**
  * @class NotifyView
@@ -40,6 +51,7 @@ export default class NotifyView extends Backbone.View {
 
   initialize() {
     this._stack = [];
+    this._notifiedErrors = {};
 
     this.notifyPushes = new NotifyPushCollection();
 
@@ -50,7 +62,48 @@ export default class NotifyView extends Backbone.View {
       'notify:prompt': this._deprecated.bind(this, 'prompt'),
       'notify:push': this._deprecated.bind(this, 'push')
     });
+    this.listenTo(logging, 'log:error log:fatal', this.onErrorLogged);
     this.render();
+  }
+
+  /**
+   * Optionally surfaces error/fatal logs as on-screen push notifications so a
+   * non-developer author previewing a course can see them. Gated by the
+   * `_logging._notify` config; the console output is unchanged either way.
+   * @param {Object} level - The {@link LOG_LEVEL} of the log entry
+   * @param {Array} data - The arguments passed to the log call
+   * @private
+   */
+  onErrorLogged(level, data) {
+
+    const config = this._getNotifyOnErrorConfig();
+    if (!config._isEnabled) return;
+
+    const minimumLevel = LOG_LEVEL(config._level.toUpperCase());
+    if (!minimumLevel || level < minimumLevel) return;
+
+    const message = data.map(String).join(' ');
+    if (this._hasNotifiedError(message)) return;
+
+    this.push({
+      body: message,
+      _classes: 'notify-push--error',
+      _timeout: config._timeout
+    });
+
+  }
+
+  _getNotifyOnErrorConfig() {
+    const loggingConfig = Adapt.config?.get('_logging');
+    return Object.assign({}, NOTIFY_ON_ERROR_DEFAULTS, loggingConfig?._notify);
+  }
+
+  _hasNotifiedError(message) {
+    if (this._notifiedErrors[message]) {
+      return true;
+    }
+    this._notifiedErrors[message] = true;
+    return false;
   }
 
   onDataReady() {

--- a/less/core/notifyPush.less
+++ b/less/core/notifyPush.less
@@ -17,6 +17,20 @@
     left: 0;
   }
 
+  // Error variant used by logging notifications. Fixed system colours that
+  // echo the browser console's error styling (red outline, pink fill), kept
+  // independent of theme variables so diagnostics look consistent per project.
+  // Doubled class (`.notify-push.notify-push--error`) so the fill beats the
+  // theme's `.notify-push` background rule regardless of stylesheet order.
+  &&--error {
+    background-color: #fdecea;
+    border: 1px solid #d93025;
+
+    .notify-push__body-inner {
+      color: #d93025;
+    }
+  }
+
   &__inner {
     cursor: pointer;
   }

--- a/schema/config.model.schema
+++ b/schema/config.model.schema
@@ -444,6 +444,41 @@
           "inputType": "Checkbox",
           "validators": [],
           "title": "Show only first deprecated and removed warnings?"
+        },
+        "_notify": {
+          "type": "object",
+          "title": "Notify on error",
+          "properties": {
+            "_isEnabled": {
+              "type": "boolean",
+              "default": false,
+              "inputType": "Checkbox",
+              "validators": [],
+              "title": "Show on-screen notifications for errors?",
+              "help": "When enabled, error and fatal log messages are also shown as on-screen push notifications. Intended for authors previewing a course; leave disabled for published courses so learners do not see them."
+            },
+            "_level": {
+              "type": "string",
+              "default": "error",
+              "title": "Minimum level to notify",
+              "validators": [],
+              "inputType": {
+                "type": "Select",
+                "options": [
+                  "error",
+                  "fatal"
+                ]
+              }
+            },
+            "_timeout": {
+              "type": "number",
+              "default": 15000,
+              "inputType": "Number",
+              "validators": [],
+              "title": "Notification timeout (ms)",
+              "help": "How long each notification stays on screen before fading. Notifications can also be dismissed manually."
+            }
+          }
         }
       }
     },

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -392,6 +392,35 @@
           "type": "boolean",
           "title": "Suppress subsequent deprecation warnings",
           "default": true
+        },
+        "_notify": {
+          "type": "object",
+          "title": "Notify on error",
+          "default": {},
+          "properties": {
+            "_isEnabled": {
+              "type": "boolean",
+              "title": "Show on-screen notifications for errors",
+              "description": "When enabled, error and fatal log messages are also shown as on-screen push notifications. Intended for authors previewing a course; leave disabled for published courses so learners do not see them.",
+              "default": false
+            },
+            "_level": {
+              "type": "string",
+              "title": "Minimum level to notify",
+              "default": "error",
+              "enum": [
+                "error",
+                "fatal"
+              ],
+              "_backboneForms": "Select"
+            },
+            "_timeout": {
+              "type": "number",
+              "title": "Notification timeout (ms)",
+              "description": "How long each notification stays on screen before fading. Notifications can also be dismissed manually.",
+              "default": 15000
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
Fixes #871

### New

Adds an opt-in mode where `error` and `fatal` log messages are also shown as on-screen push notifications, not only written to the browser console. This gives non-developer authors visibility of problems they would otherwise miss, so they can report them to a developer. The console output is unchanged.

The consumer lives in the notify view and subscribes to logging's existing `log:error`/`log:fatal` events, so _logging.js_ is untouched and no new module dependencies are introduced. Notifications are deduplicated by message, show only the logged message (no stack trace), and use a generous, manually dismissable timeout. They are styled with fixed system colours to echo the browser console's error styling.

Behaviour is gated by a new `_logging._notify` config block, disabled by default so published courses do not surface errors to learners. Authors enable it when previewing. Added to both the modern (`config.schema.json`) and legacy (`config.model.schema`) schemas.

Config:

```json
"_logging": {
  "_notify": {
    "_isEnabled": false,
    "_level": "error",
    "_timeout": 15000
  }
}
```

* `_isEnabled` (default `false`): off unless the author opts in.
* `_level` (`error` or `fatal`, default `error`): minimum level to notify.
* `_timeout` (default `15000`): how long each notification stays before fading; can also be dismissed manually.

### Testing

1. In a course `config.json`, set `_logging._notify._isEnabled` to `true`.
2. Trigger an error, for example by running `require('core/js/logging').error('Test error')` in the browser console, or by loading a course with a known misconfiguration.
3. Confirm the message appears as a push notification in the top-right, with red outline and pink fill, and also in the console.
4. Fire the same message twice and confirm the second does not produce a duplicate notification.
5. Set `_isEnabled` back to `false` and confirm no notification appears.

---

Posted via collaboration with Claude Code