### PR TITLE
Fix: normalise legacy non-object menuSettings on migration (fixes #873)

### DIFF
--- a/migrations/v6.js
+++ b/migrations/v6.js
@@ -1,6 +1,53 @@
 import { describe, whereContent, whereFromPlugin, mutateContent, checkContent, updatePlugin, getCourse, testSuccessWhere, testStopWhere, getConfig } from 'adapt-migrations';
 import _ from 'lodash';
 
+describe('core - update to v6.0.0', async () => {
+  let course;
+
+  const isObject = (value) => (typeof value === 'object' && value !== null && !Array.isArray(value));
+
+  whereFromPlugin('core - from less than v6.0.0', { name: 'adapt-contrib-core', version: '<6.0.0' });
+
+  whereContent('core - where course menuSettings is not an object', async (content) => {
+    course = getCourse();
+    return course && !isObject(course.menuSettings);
+  });
+
+  mutateContent('core - normalise course.menuSettings to an object', async (content) => {
+    _.set(course, 'menuSettings', {});
+    return true;
+  });
+
+  checkContent('core - check course.menuSettings is an object', async (content) => {
+    if (!isObject(_.get(course, 'menuSettings'))) throw new Error('core - menuSettings not normalised to an object');
+    return true;
+  });
+
+  updatePlugin('core - update to v6.0.0', { name: 'adapt-contrib-core', version: '6.0.0', framework: '>=5.17.0' });
+
+  testSuccessWhere('legacy string menuSettings', {
+    fromPlugins: [{ name: 'adapt-contrib-core', version: '5.12.0' }],
+    content: [
+      { _type: 'course', menuSettings: '' }
+    ]
+  });
+
+  testStopWhere('menuSettings already an object', {
+    fromPlugins: [{ name: 'adapt-contrib-core', version: '5.12.0' }],
+    content: [
+      { _type: 'course', menuSettings: {} }
+    ]
+  });
+
+  testStopWhere('incorrect version', {
+    fromPlugins: [{ name: 'adapt-contrib-core', version: '6.0.0' }]
+  });
+
+  testStopWhere('no course', {
+    content: [{ _type: 'config' }]
+  });
+});
+
 describe('core - update to v6.22.0', async () => {
   let course;
   const defaultNavigation = {


### PR DESCRIPTION
Fixes #873

### Fix
- Added a `< 6.0.0` migration block to `migrations/v6.js` that normalises `course.menuSettings` to `{}` when it is not already an object. `menuSettings` was introduced as an object (`default: {}`) in v6.0.0 (#3230); courses authored before then can carry a non-object value (e.g. an empty string `""`), which fails the current course schema (`course: /menuSettings must be object`). No existing migration covered this (they start at `< 6.22.0`).
- The `whereContent` only matches when the value is not already an object, so a populated `menuSettings` on newer content is never overwritten.

### Testing
1. `grunt migration:test --file=core`
2. The new `core - update to v6.0.0` scenarios pass: legacy string `menuSettings: ''` is normalised to `{}`; an already-object `menuSettings` correctly stops (no change); wrong version and no-course cases stop.
