### PR TITLE
Update: state displayTitle's link to title in the schema (fixes #875)

### DIFF
--- a/schema/content.schema.json
+++ b/schema/content.schema.json
@@ -39,7 +39,8 @@
       "description": "When viewing an element - this is the title that will be displayed on the page",
       "default": "",
       "_adapt": {
-        "translatable": true
+        "translatable": true,
+        "linkedTo": "title"
       },
       "_backboneForms": "DisplayTitle"
     },


### PR DESCRIPTION
Fixes #875

### Update
* Add `_adapt.linkedTo: "title"` to `displayTitle`, stating the relationship the `DisplayTitle` editor name currently only implies.

`_backboneForms` is left untouched, so anything consuming it behaves exactly as before — this is purely additive, and an annotation either way, so there's no runtime change and existing content is unaffected. The same key is proposed for the large/small image pair in adaptlearning/adapt-contrib-graphic#132, which is what makes it a reusable vocabulary rather than a second special case.

### Testing
1. Confirm `schema/content.schema.json` still parses and content renders as before — the added keyword is inert at runtime.
