### PR TITLE
Fix: Close the requested popup layer rather than the top of the stack (fixes #878)

### DIFF
--- a/js/a11y/popup.js
+++ b/js/a11y/popup.js
@@ -187,16 +187,23 @@ export default class Popup extends Backbone.Controller {
    * @returns {Promise<Popup>} Returns a promise that resolves to this for method chaining.
    */
   async closed($forceFocusElement, silent) {
+    // capture the layer being closed as another popup can be opened whilst waiting
+    const closingIndex = this._floorStack.length - 1;
+    const $closingElement = this._floorStack[closingIndex];
     if (!silent) {
       Adapt.trigger('popup:closing');
       await wait.queue();
     }
-    const $previousFocusElement = this._removeLastPopupLayer();
+    const wasLastPopupLayer = (this._floorStack[this._floorStack.length - 1] === $closingElement);
+    const $previousFocusElement = this._removePopupLayerAt(closingIndex, $closingElement);
     const $focusElement = $forceFocusElement || $previousFocusElement || $('body');
     if (!silent) {
       Adapt.trigger('popup:closed', $focusElement, true);
     }
-    this.a11y.focusFirst($($focusElement), { preventScroll: true });
+    // leave the focus with the newer popup as it now owns the top of the stack
+    if (wasLastPopupLayer) {
+      this.a11y.focusFirst($($focusElement), { preventScroll: true });
+    }
     return this;
   }
 
@@ -211,14 +218,45 @@ export default class Popup extends Backbone.Controller {
    *                            or undefined if no popup was open.
    */
   _removeLastPopupLayer() {
+    return this._removePopupLayerAt(this._floorStack.length - 1);
+  }
+
+  /**
+   * Restores tabbing and screen reader access to the state before the
+   * `_addPopupLayer` call which added the layer at the specified index.
+   * Removes that popup from the stack and restores the original tabindex and
+   * aria-hidden attribute values for all affected elements. For native dialog elements,
+   * closes them using the dialog.close() API.
+   * @private
+   * @param {number} index - Index of the layer in the popup stack.
+   * @param {jQuery} [$expectedElement=null] - Layer expected at that index. When it does
+   *                                           not match, the layer has already been
+   *                                           removed and nothing is done.
+   * @returns {jQuery|undefined} Returns the previously active element as a jQuery object,
+   *                            or undefined if no popup was removed.
+   */
+  _removePopupLayerAt(index, $expectedElement = null) {
     // the body layer is the first element and must always exist
-    if (this._floorStack.length <= 1) {
+    if (index < 1 || index >= this._floorStack.length) {
       return;
     }
-    const $popupElement = this._floorStack.pop();
-    if ($popupElement.is('dialog')) {
+    const $popupElement = this._floorStack[index];
+    // the layer has already been removed
+    if ($expectedElement && $popupElement !== $expectedElement) {
+      return;
+    }
+    const isDialog = $popupElement.is('dialog');
+    const isLastPopupLayer = (index === this._floorStack.length - 1);
+    if (!isDialog && !isLastPopupLayer) {
+      // tabindex and aria-hidden states are stored in stack order so can only be restored from the top down
+      logging.warn('a11y/popup: cannot close a non-dialog popup whilst a newer popup is open', $popupElement);
+      return;
+    }
+    this._floorStack.splice(index, 1);
+    const $previousFocusElement = this._focusStack.splice(index - 1, 1)[0];
+    if (isDialog) {
       $popupElement[0].close();
-      return this._focusStack.pop();
+      return $previousFocusElement;
     }
     const config = this.a11y.config;
     if (!config._isEnabled || !config._options._isPopupManagementEnabled) {
@@ -262,7 +300,7 @@ export default class Popup extends Backbone.Controller {
         }
       }
     });
-    return this._focusStack.pop();
+    return $previousFocusElement;
   }
 
   /**


### PR DESCRIPTION
Fixes #878

### Fix

* `Popup.closed()` now captures the layer it was asked to close before awaiting the wait queue, and removes that layer afterwards. Previously it always popped the top of the stack, so a popup opened during the wait was closed in place of the intended one, leaving the intended one on the stack as an open modal dialog with its backdrop blocking the page.
* Focus is only restored when the closed layer was still the top of the stack. When a newer popup is open it keeps the focus rather than having it pulled back to the older popup's opener.
* `_removeLastPopupLayer()` is kept as a wrapper around the new `_removePopupLayerAt()`, so its behaviour is unchanged for existing callers.

Legacy non-dialog popups can only have their tabindex and `aria-hidden` states restored from the top down, as those states are stored in stack order. Closing one whilst a newer popup is open now warns and leaves the stack alone instead of corrupting the stored states.

### Testing

The bug and the fix are both easiest to see from the console.

1. Load any course and open the drawer:

   ```js
   require('core/js/drawer').open();
   ```

2. Once it is open, close it and open a notify alert in the same tick:

   ```js
   require('core/js/drawer').close();
   require('core/js/notify').alert({ title: 'Test', body: 'Test' });
   ```

3. Before this change the alert closes the instant it opens, the drawer never closes, and the page cannot be clicked or focused — `document.querySelector('dialog.drawer').matches(':modal')` stays `true`. After this change the drawer closes, and the alert opens and keeps focus.

Also worth checking that normal popup behaviour is unaffected:

* Open and close the drawer, and open and close a notify alert. Focus should return to whatever opened each one.
* Open a notify alert on top of an open drawer, close the alert, then close the drawer. The drawer should still be modal after the alert closes, and the stack should unwind cleanly.

Tested in Chrome 151 on macOS against Adapt Framework v5.56.2, both through the console steps above and through a real course where selecting a page from the Page Level Progress drawer triggers a page incomplete prompt on the same navigation.

Posted via collaboration with Claude Code
